### PR TITLE
chore(deps): bump prisma major version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "hasInstallScript": true,
       "license": "GPL-3",
       "dependencies": {
-        "@prisma/client": "2.30.3",
+        "@prisma/client": "3.0.2",
         "next": "11.1.2",
         "next-iron-session": "4.2.0",
         "react": "17.0.2",
@@ -41,7 +41,7 @@
         "husky": "7.0.2",
         "lint-staged": "11.1.2",
         "prettier": "2.3.2",
-        "prisma": "2.30.3",
+        "prisma": "3.0.2",
         "typescript": "4.4.2"
       }
     },
@@ -1450,15 +1450,15 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "2.30.3",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.30.3.tgz",
-      "integrity": "sha512-Ey2miZ+Hne12We3rA8XrlPoAF0iuKEhw5IK2nropaelSt0Ju3b2qSz9Qt50a/1Mx3+7yRSu/iSXt8y9TUMl/Yw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.0.2.tgz",
+      "integrity": "sha512-6SrDYY2Yr5AmYpVB3XAXFqfzxKMdDTemXR7FmfXthnxWhQHoBwRLNZ3B3GyI/MmWa5tr+kaaGDJjp1LU0vuYvQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
+        "@prisma/engines-version": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
       },
       "engines": {
-        "node": ">=12.2"
+        "node": ">=12.6"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -1470,16 +1470,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20.tgz",
-      "integrity": "sha512-WPnA/IUrxDihrRhdP6+8KAVSwsc0zsh8ioPYsLJjOhzVhwpRbuFH2tJDRIAbc+qFh+BbTIZbeyBYt8fpNXaYQQ==",
+      "version": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db.tgz",
+      "integrity": "sha512-Q9CwN6e5E5Abso7J3A1fHbcF4NXGRINyMnf7WQ07fXaebxTTARY5BNUzy2Mo5uH82eRVO5v7ImNuR044KTjLJg==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20.tgz",
-      "integrity": "sha512-/iDRgaoSQC77WN2oDsOM8dn61fykm6tnZUAClY+6p+XJbOEgZ9gy4CKuKTBgrjSGDVjtQ/S2KGcYd3Ring8xaw=="
+      "version": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db.tgz",
+      "integrity": "sha512-iArSApZZImVmT9oC/rGOjzvpG2AOqlIeqYcVnop9poA3FxD4zfVPbNPH9DTgOWhc06OkBHujJZeAcsNddVabIQ=="
     },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.0.6",
@@ -7684,20 +7684,20 @@
       }
     },
     "node_modules/prisma": {
-      "version": "2.30.3",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.30.3.tgz",
-      "integrity": "sha512-48qYba2BIyUmXuosBZs0g3kYGrxKvo4VkSHYOuLlDdDirmKyvoY2hCYMUYHSx3f++8ovfgs+MX5KmNlP+iAZrQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.0.2.tgz",
+      "integrity": "sha512-TyOCbtWGDVdWvsM1RhUzJXoGClXGalHhyYWIc5eizSF8T1ScGiOa34asBUdTnXOUBFSErbsqMNw40DHAteBm1A==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
+        "@prisma/engines": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
       },
       "bin": {
         "prisma": "build/index.js",
         "prisma2": "build/index.js"
       },
       "engines": {
-        "node": ">=12.2"
+        "node": ">=12.6"
       }
     },
     "node_modules/process": {
@@ -10664,23 +10664,23 @@
       }
     },
     "@prisma/client": {
-      "version": "2.30.3",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.30.3.tgz",
-      "integrity": "sha512-Ey2miZ+Hne12We3rA8XrlPoAF0iuKEhw5IK2nropaelSt0Ju3b2qSz9Qt50a/1Mx3+7yRSu/iSXt8y9TUMl/Yw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.0.2.tgz",
+      "integrity": "sha512-6SrDYY2Yr5AmYpVB3XAXFqfzxKMdDTemXR7FmfXthnxWhQHoBwRLNZ3B3GyI/MmWa5tr+kaaGDJjp1LU0vuYvQ==",
       "requires": {
-        "@prisma/engines-version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
+        "@prisma/engines-version": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
       }
     },
     "@prisma/engines": {
-      "version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20.tgz",
-      "integrity": "sha512-WPnA/IUrxDihrRhdP6+8KAVSwsc0zsh8ioPYsLJjOhzVhwpRbuFH2tJDRIAbc+qFh+BbTIZbeyBYt8fpNXaYQQ==",
+      "version": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db.tgz",
+      "integrity": "sha512-Q9CwN6e5E5Abso7J3A1fHbcF4NXGRINyMnf7WQ07fXaebxTTARY5BNUzy2Mo5uH82eRVO5v7ImNuR044KTjLJg==",
       "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20.tgz",
-      "integrity": "sha512-/iDRgaoSQC77WN2oDsOM8dn61fykm6tnZUAClY+6p+XJbOEgZ9gy4CKuKTBgrjSGDVjtQ/S2KGcYd3Ring8xaw=="
+      "version": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db.tgz",
+      "integrity": "sha512-iArSApZZImVmT9oC/rGOjzvpG2AOqlIeqYcVnop9poA3FxD4zfVPbNPH9DTgOWhc06OkBHujJZeAcsNddVabIQ=="
     },
     "@rushstack/eslint-patch": {
       "version": "1.0.6",
@@ -15408,12 +15408,12 @@
       }
     },
     "prisma": {
-      "version": "2.30.3",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.30.3.tgz",
-      "integrity": "sha512-48qYba2BIyUmXuosBZs0g3kYGrxKvo4VkSHYOuLlDdDirmKyvoY2hCYMUYHSx3f++8ovfgs+MX5KmNlP+iAZrQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.0.2.tgz",
+      "integrity": "sha512-TyOCbtWGDVdWvsM1RhUzJXoGClXGalHhyYWIc5eizSF8T1ScGiOa34asBUdTnXOUBFSErbsqMNw40DHAteBm1A==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
+        "@prisma/engines": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
       }
     },
     "process": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "@prisma/client": "2.30.3",
+    "@prisma/client": "3.0.2",
     "next": "11.1.2",
     "next-iron-session": "4.2.0",
     "react": "17.0.2",
@@ -59,7 +59,7 @@
     "husky": "7.0.2",
     "lint-staged": "11.1.2",
     "prettier": "2.3.2",
-    "prisma": "2.30.3",
+    "prisma": "3.0.2",
     "typescript": "4.4.2"
   },
   "config": {


### PR DESCRIPTION
Signed-off-by: Arthelon <hsing.daniel@gmail.com>

### Description

Bumps version of Prisma from `2.30.3` to `3.0.2`

### Test Plan
- `npm run dev`
- `npx prisma db push`


