### PR TITLE
Dynamic route for Chapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.\*
+
+# VSCode settings
+/.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "pencils-for-success",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "GPL-3",

--- a/src/pages/chapters/[chapterName].tsx
+++ b/src/pages/chapters/[chapterName].tsx
@@ -1,3 +1,5 @@
+import { Container, Heading } from '@chakra-ui/react';
+
 interface ChapterMapPageProps {
   chapterName: string;
 }
@@ -9,7 +11,11 @@ interface IStaticPropsContextParams {
 }
 
 export default function ChapterMapPage({ chapterName }: ChapterMapPageProps) {
-  return <h1>{chapterName}</h1>;
+  return (
+    <Container py="5">
+      <Heading textAlign="center">{chapterName.toUpperCase()}</Heading>
+    </Container>
+  );
 }
 
 export async function getStaticPaths() {

--- a/src/pages/chapters/[chapterName].tsx
+++ b/src/pages/chapters/[chapterName].tsx
@@ -1,0 +1,30 @@
+interface ChapterMapPageProps {
+  chapterName: string;
+}
+
+interface IStaticPropsContextParams {
+  params: {
+    chapterName: string;
+  };
+}
+
+export default function ChapterMapPage({ chapterName }: ChapterMapPageProps) {
+  return <h1>{chapterName}</h1>;
+}
+
+export async function getStaticPaths() {
+  // TODO: Retrieve the data from the database
+  const chapters = ['georgia', 'kansas', 'texas'];
+
+  const paths = chapters.map((chapterName) => ({
+    params: { chapterName },
+  }));
+
+  return { paths, fallback: false };
+}
+
+export async function getStaticProps({ params }: IStaticPropsContextParams) {
+  const { chapterName } = params;
+
+  return { props: { chapterName } };
+}


### PR DESCRIPTION
### Description
This feature will allow us to build a valid chapter's map page dynamically.
- The list of chapters is used to generate valid routes using `getStaticPaths` method. Currently, this list is hard-coded.
  - If there is a match for a route with the generated route, we use `getStaticProps` to retrieve the chapter passed on the URL and pass it for rendering.
  - If there is no match, the provided route will be redirected to 404 page by setting `fallback: false`.

- If the valid chapter is passed, the chapter name is displayed on the page.


**Related Issues/PRs:** 

List of related issues/PRs and the type of association. For example:
- Closes #10 

### Test Plan
- Navigate to `/chapters/georgia`, `/chapters/kansas`, and `/chapters/texas`. For each route, it will display `Georgia`, `Kansas`, and `Texas` respectively.
- Navigating to `/chapters/alabama` will display 404 error page
- Navigating to `/chapters/gt` will display 404 error page
- Navigating to `/chapters` page will display 404 error page

