### PR TITLE
feat(ci): add sync-db CI job and NPM script to run db push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Check PR
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   run-ci:
@@ -32,3 +32,13 @@ jobs:
 
       - name: Check commits messages
         uses: wagoid/commitlint-github-action@v4
+  sync-db:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: run-ci
+    name: Synchronize cloud DB
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push prisma schema changes
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        runs: npm run db:push

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --ignore-path .gitignore \"src/**/*.+(ts|js|tsx)\" --write",
     "postinstall": "husky install",
     "commit": "cz",
+    "db:push": "prisma db push",
     "secrets": "npm run secrets:logout && cross-env-shell BW_SESSION=`bw login product@bitsofgood.org --raw` \"npm run secrets:sync\"",
     "secrets:logout": "(bw logout || exit 0)",
     "secrets:login": "bw login product@bitsofgood.org",


### PR DESCRIPTION
Signed-off-by: Arthelon <hsing.daniel@gmail.com>

### Description

After PRs containing schema changes are deployed, the development cloud DB should be automatically to match these changes. This PR adds a CI job to do that.

