### PR TITLE
Endpoint for fetching chapters

### DIFF
--- a/src/pages/api/chapters/index.ts
+++ b/src/pages/api/chapters/index.ts
@@ -1,19 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { Chapter, PrismaClient } from '@prisma/client';
 import { ErrorResponse } from '@/utils/types';
 
 type DataResponse = {
-  chapters: string[];
+  chapters: Chapter[];
 };
 
-export default function handler(
+export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<DataResponse | ErrorResponse>,
 ) {
   switch (req.method) {
     case 'GET':
       try {
-        // TODO - Use Prisma to find Chapters
-        const chapters: string[] = ['Georgia'];
+        const prisma = new PrismaClient();
+        const chapters = await prisma.chapter.findMany();
 
         return res.status(200).json({ chapters });
       } catch (e) {

--- a/src/pages/api/chapters/index.ts
+++ b/src/pages/api/chapters/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { Chapter, PrismaClient } from '@prisma/client';
+import { Chapter, PrismaClient, Prisma } from '@prisma/client';
 import { ErrorResponse } from '@/utils/types';
 
 type DataResponse = {
@@ -18,9 +18,13 @@ export default async function handler(
 
         return res.status(200).json({ chapters });
       } catch (e) {
-        return res
-          .status(500)
-          .json({ error: true, message: (e as Error).message });
+        let { message } = e as Error;
+
+        if (e instanceof Prisma.PrismaClientInitializationError) {
+          message = 'Failed to connect to the database';
+        }
+
+        return res.status(500).json({ error: true, message });
       }
 
       break;

--- a/src/pages/api/chapters/index.ts
+++ b/src/pages/api/chapters/index.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { ErrorResponse } from '@/utils/types';
+
+type DataResponse = {
+  chapters: string[];
+};
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<DataResponse | ErrorResponse>,
+) {
+  switch (req.method) {
+    case 'GET':
+      try {
+        // TODO - Use Prisma to find Chapters
+        const chapters: string[] = ['Georgia'];
+
+        return res.status(200).json({ chapters });
+      } catch (e) {
+        return res
+          .status(500)
+          .json({ error: true, message: (e as Error).message });
+      }
+
+      break;
+    default:
+      res.setHeader('Allow', ['GET']);
+      return res
+        .status(405)
+        .json({ error: true, message: `Method ${req.method} Not Allowed` });
+  }
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,4 @@
+export interface ErrorResponse {
+  error: true;
+  message: string;
+}


### PR DESCRIPTION
### Description
Added a GET endpoint `/api/chapters`.
This returns a list of all chapters. If no chapter is found, it returns an empty list.
```
{
  chapters: [
    {
      id: 1,
      contactName: "Georgia",
      email: "georgia.chapter@pfs.com"
    }
  ]
}
```
If there is some server error when retrieving the chapters, an error message is returned in the following format:
```
{
  error: true,
  message: 'Short message for explain what the error is'
}
```

**Related Issues/PRs:** 

List of related issues/PRs and the type of association. For example:
- Closes #28 

### Test Plan

List of steps to test your proposed changes:
- Make a GET API call to `/api/chapters`. It should return a list of available chapters. Check Prisma to ensure all the chapters included in the database are returned.
- Remove or break the URL for the database (invalid database connection string). Make the API call. It should return an error message.
- Make API to `/api/chapters` using HTTP method other than `GET`. It should reject the request.

