### PR TITLE
Endpoint to Create Chapter (with Chapter User)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,12 +47,12 @@ model Recipient {
   email         String
   phoneNumber   String
   location      String
-  RecipientUser RecipientUser?
+  recipientUser RecipientUser?
 }
 
 model Chapter {
   id          Int          @id @default(autoincrement())
   contactName String
   email       String       @unique
-  ChapterUser ChapterUser?
+  chapterUser ChapterUser?
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,8 +42,8 @@ model RecipientUser {
 }
 
 model Recipient {
-  id            Int             @id @default(autoincrement())
-  name          String          @unique
+  id            Int            @id @default(autoincrement())
+  name          String         @unique
   email         String
   phoneNumber   String
   location      String
@@ -51,8 +51,8 @@ model Recipient {
 }
 
 model Chapter {
-  id          Int           @id @default(autoincrement())
+  id          Int          @id @default(autoincrement())
   contactName String
-  email       String        @unique
+  email       String       @unique
   ChapterUser ChapterUser?
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -56,7 +56,7 @@ async function main() {
     create: {
       contactName: 'Georgia',
       email: 'georgia@pfs.org',
-      ChapterUser: {
+      chapterUser: {
         create: {
           name: 'Georgia Chapter User',
           email: 'georgia_user@pfs.org',

--- a/src/pages/api/chapters/index.ts
+++ b/src/pages/api/chapters/index.ts
@@ -4,6 +4,11 @@ import { ErrorResponse, serverErrorHandler } from '@/utils/error';
 import { NextIronRequest, withSession } from '@/utils/session';
 import { SessionAdminUser } from '../admin/login';
 import { getPasswordHash } from '@/utils/password';
+import {
+  validateChapterInput,
+  validateNewChapterUserInput,
+  validateNewUserInput,
+} from '@/utils/prisma-validation';
 
 type DataResponse = {
   chapters: Chapter[];
@@ -16,56 +21,6 @@ export type ChapterInputBody = {
     user: Prisma.UserCreateInput;
   };
 };
-
-/**
- * Checks if the provided chapter input is valid before storing in the database
- * @param chapter User input
- */
-function validateChapterInput(chapter: Prisma.ChapterCreateInput) {
-  const { contactName, email } = chapter || {};
-
-  if (!contactName || contactName.trim().length === 0) {
-    throw Error('Please provide a valid contact name');
-  }
-
-  if (!email || email.trim().length === 0) {
-    throw Error('Please provide a valid email');
-  }
-}
-
-/**
- * Checks if the provided chapter user input is valid before storing in the database
- * @param chapter User input
- */
-function validateNewChapterUserInput(
-  chapterUser: Prisma.ChapterUserCreateInput | undefined,
-) {
-  const { name, email } = chapterUser || {};
-
-  if (!name || name.trim().length === 0) {
-    throw Error('Please provide a valid name for the chapter user');
-  }
-
-  if (!email || email.trim().length === 0) {
-    throw Error('Please provide a valid email for the chapter user');
-  }
-}
-
-/**
- * Checks if the provided user input is valid before storing in the database
- * @param chapter User input
- */
-function validateNewUserInput(user: Prisma.UserCreateInput | undefined) {
-  const { username, hash } = user || {};
-
-  if (!username || username.trim().length === 0) {
-    throw Error('Please provide a valid username for the user');
-  }
-
-  if (!hash || hash.trim().length === 0) {
-    throw Error('Please provide a valid password for the user');
-  }
-}
 
 async function handler(
   req: NextIronRequest,

--- a/src/pages/api/chapters/index.ts
+++ b/src/pages/api/chapters/index.ts
@@ -1,13 +1,31 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiResponse } from 'next';
 import { Chapter, PrismaClient, Prisma } from '@prisma/client';
-import { ErrorResponse } from '@/utils/types';
+import { ErrorResponse, serverErrorHandler } from '@/utils/error';
+import { NextIronRequest, withSession } from '@/utils/session';
+import { SessionAdminUser } from '../admin/login';
 
 type DataResponse = {
   chapters: Chapter[];
 };
 
-export default async function handler(
-  req: NextApiRequest,
+/**
+ * Checks if the provided chapter input is valid before storing in the database
+ * @param chapter User input
+ */
+function validateChapterInput(chapter: Prisma.ChapterCreateInput) {
+  const { contactName, email } = chapter || {};
+
+  if (!contactName || contactName.trim().length === 0) {
+    throw Error('Please provide a valid contact name');
+  }
+
+  if (!email || email.trim().length === 0) {
+    throw Error('Please provide a valid email');
+  }
+}
+
+async function handler(
+  req: NextIronRequest,
   res: NextApiResponse<DataResponse | ErrorResponse>,
 ) {
   switch (req.method) {
@@ -18,16 +36,37 @@ export default async function handler(
 
         return res.status(200).json({ chapters });
       } catch (e) {
-        let { message } = e as Error;
-
-        if (e instanceof Prisma.PrismaClientInitializationError) {
-          message = 'Failed to connect to the database';
-        }
-
-        return res.status(500).json({ error: true, message });
+        return serverErrorHandler(e, res);
       }
 
-      break;
+    case 'POST':
+      try {
+        const user = req.session.get('user') as SessionAdminUser;
+
+        // Check if requesting user is logged in and is an admin
+        if (!user || !user.isLoggedIn || !user.admin) {
+          return res.status(401).json({
+            error: true,
+            message: 'Please login as an admin to create a new chapter',
+          });
+        }
+
+        // Validate user input
+        const chapter = req.body.chapter as Prisma.ChapterCreateInput;
+        validateChapterInput(chapter);
+
+        const prisma = new PrismaClient();
+        await prisma.chapter.create({
+          data: chapter,
+        });
+
+        return res
+          .status(200)
+          .json({ error: false, message: 'Successfully created a chapter' });
+      } catch (e) {
+        return serverErrorHandler(e, res);
+      }
+
     default:
       res.setHeader('Allow', ['GET']);
       return res
@@ -35,3 +74,5 @@ export default async function handler(
         .json({ error: true, message: `Method ${req.method} Not Allowed` });
   }
 }
+
+export default withSession(handler);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,34 @@
+import { Prisma } from '@prisma/client';
+import { NextApiResponse } from 'next';
+
+export interface ErrorResponse {
+  error: boolean;
+  message: string;
+}
+
+/**
+ * This is a default handler for errors that occur on the server side
+ * @param e Error
+ * @param res Next Response
+ * @returns Next Response with error message
+ */
+export function serverErrorHandler(
+  e: any,
+  res: NextApiResponse<ErrorResponse>,
+) {
+  // Error logging
+  // console.error(e);
+
+  let { message = 'Server Error' } = e as Error;
+
+  if (e instanceof Prisma.PrismaClientInitializationError) {
+    message = 'Failed to connect to the database';
+  }
+
+  if (e instanceof Prisma.PrismaClientValidationError) {
+    message = 'Please provide valid arguments for database query';
+  }
+
+  res.status(500).json({ error: true, message });
+  return res;
+}

--- a/src/utils/prisma-validation.ts
+++ b/src/utils/prisma-validation.ts
@@ -1,0 +1,55 @@
+import { Prisma } from '@prisma/client';
+
+export function validateEmail(email: string | undefined) {
+  if (!email || email.trim().length === 0) {
+    throw Error('Please provide a valid email');
+  }
+}
+
+/**
+ * Checks if the provided chapter input is valid before storing in the database
+ * @param chapter User input
+ */
+export function validateChapterInput(
+  chapter: Prisma.ChapterCreateInput | undefined,
+) {
+  const { contactName, email } = chapter || {};
+
+  if (!contactName || contactName.trim().length === 0) {
+    throw Error('Please provide a valid contact name');
+  }
+
+  validateEmail(email);
+}
+
+/**
+ * Checks if the provided chapter user input is valid before storing in the database
+ * @param chapter User input
+ */
+export function validateNewChapterUserInput(
+  chapterUser: Prisma.ChapterUserCreateInput | undefined,
+) {
+  const { name, email } = chapterUser || {};
+
+  if (!name || name.trim().length === 0) {
+    throw Error('Please provide a valid name for the chapter user');
+  }
+
+  validateEmail(email);
+}
+
+/**
+ * Checks if the provided user input is valid before storing in the database
+ * @param chapter User input
+ */
+export function validateNewUserInput(user: Prisma.UserCreateInput | undefined) {
+  const { username, hash } = user || {};
+
+  if (!username || username.trim().length === 0) {
+    throw Error('Please provide a valid username for the user');
+  }
+
+  if (!hash || hash.trim().length === 0) {
+    throw Error('Please provide a valid password for the user');
+  }
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,0 @@
-export interface ErrorResponse {
-  error: true;
-  message: string;
-}


### PR DESCRIPTION
### Description
Added the endpoint `POST /api/chapter` to create a new chapter (and chapter user if applicable). This endpoint is protected and only admin users are authorized to access it.

To create a chapter only, the request body should specify chapter to be created only:
```
{
    "chapter": {
        "contactName": "Kansas",
        "email": "kansas@pfs.org"
    }
}
```

To create a chapter with new chapter user, the request should specify chapter and new user:
```
{
    "chapter": {
        "contactName": "Kansas",
        "email": "kansas@pfs.org"
    },
    "newUser": {
        "chapterUser": {
            "name": "Kansas Chapter User",
            "email": "kansas_user@pfs.org"
        },
        "user": {
            "username": "kansas_chapter",
            "hash": "bog_kansas_chapter"
        }
    }
}
```

**Related Issues/PRs:** 

List of related issues/PRs and the type of association. For example:
- Closes #39 

### Test Plan
**Unauthenticated requests**
- Logout (remove any cookies) before sending the request.
- Create a chapter by sending the POST request. It should throw HTTP 401 error.

**Authenticated requests**
- Login as an admin user. Store the returned cookie for sending future requests.
- Test for creation by sending POST request for the following:
  - Chapter only
  - Chapter with new user
 - Test for duplicates.
   - Create a new chapter with a duplicate chapter name
   - Create a new chapter with new user but duplicate email and/or username. If there is error while creating a user, the chapter should not be created.
 - Test for missing fields. Send POST requests without some required fields.
   
Since no frontend components have been created to connect with this API, Postman is a great tool to test out these changes.

