### PR TITLE
Protected Admin Dashboard Page

### DIFF
--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GetServerSideProps } from 'next';
+import { Container, Heading, Text, Divider } from '@chakra-ui/react';
 import { withAdminAuthPage } from '@/utils/auth-middleware';
 import { SessionAdminUser } from '../api/admin/login';
 import { NextIronServerSideContext } from '@/utils/session';
@@ -10,10 +11,11 @@ interface AdminDashboardProps {
 
 export default function AdminDashboardPage({ user }: AdminDashboardProps) {
   return (
-    <div>
-      <h1>Admin Dashboard</h1>
-      <p>{JSON.stringify(user)}</p>
-    </div>
+    <Container py="5" textAlign="center">
+      <Heading>Admin Dashboard</Heading>
+      <Divider my={3} />
+      <Text>Admin Id: {user.admin.id}</Text>
+    </Container>
   );
 }
 

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { GetServerSideProps } from 'next';
+import { withAdminAuthPage } from '@/utils/auth-middleware';
+import { SessionAdminUser } from '../api/admin/login';
+import { NextIronServerSideContext } from '@/utils/session';
+
+interface AdminDashboardProps {
+  user: SessionAdminUser;
+}
+
+export default function AdminDashboardPage({ user }: AdminDashboardProps) {
+  return (
+    <div>
+      <h1>Admin Dashboard</h1>
+      <p>{JSON.stringify(user)}</p>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<AdminDashboardProps> =
+  withAdminAuthPage(async ({ req }: NextIronServerSideContext) => {
+    const user = req.session.get('user') as SessionAdminUser;
+
+    return {
+      props: { user },
+    };
+  });

--- a/src/utils/auth-middleware.ts
+++ b/src/utils/auth-middleware.ts
@@ -1,0 +1,25 @@
+import { SessionAdminUser } from '@/pages/api/admin/login';
+import {
+  NextIronContextHandler,
+  NextIronServerSideContext,
+  withSession,
+} from './session';
+
+export function withAdminAuthPage(handler: NextIronContextHandler) {
+  return withSession((ctx: NextIronServerSideContext) => {
+    const { req, res } = ctx;
+    const user = req.session.get('user') as SessionAdminUser;
+
+    if (!user || !user.isLoggedIn || !user.admin) {
+      res.setHeader('location', '/admin/login');
+      res.statusCode = 302;
+      res.end();
+      // Even if redirecting to a different location, getServerSideProps expects valid return
+      return {
+        props: {},
+      };
+    }
+
+    return handler(ctx, null);
+  });
+}


### PR DESCRIPTION
### Description
Add a new page under `/admin` that can only be accessed by admin users. If the user is not authenticated or is not an admin, they are redirected to the `/admin/login` page.

**Related Issues/PRs:** 

List of related issues/PRs and the type of association. For example:
- Closes #21

### Test Plan
Valid authenticated session
- Login as authenticated admin on `/admin/login`.
- Visit `/admin` page. You should see the id for the logged in admin.

Invalid session
- Remove any cookie used to store the session info.
- Visit `/admin` page. You should be redirected to `/admin/login` page.

