### PR TITLE
API route to update chapter user credentials

### DIFF
--- a/src/pages/api/chapters/users/[userId].ts
+++ b/src/pages/api/chapters/users/[userId].ts
@@ -1,0 +1,82 @@
+import type { NextApiResponse } from 'next';
+import { PrismaClient } from '@prisma/client';
+import { ErrorResponse, serverErrorHandler } from '@/utils/error';
+import { NextIronRequest } from '@/utils/session';
+import { getPasswordHash } from '@/utils/password';
+import { validatePassword, validateUsername } from '@/utils/prisma-validation';
+import { withAdminRequestSession } from '@/utils/middlewares/auth';
+
+export type NewCredentialsInput = {
+  newUsername: string;
+  newPassword: string;
+};
+
+async function handler(
+  req: NextIronRequest,
+  res: NextApiResponse<ErrorResponse>,
+) {
+  switch (req.method) {
+    case 'PUT':
+      try {
+        // Check if the provided chapter user exists
+        const prisma = new PrismaClient();
+
+        const { userId } = req.query;
+        const existingChapterUser = await prisma.chapterUser.findUnique({
+          where: {
+            id: Number(userId),
+          },
+        });
+
+        if (existingChapterUser) {
+          // Check if the user inputs are valid
+          const { newUsername, newPassword } = req.body as NewCredentialsInput;
+
+          try {
+            validateUsername(newUsername);
+            validatePassword(newPassword);
+          } catch (e) {
+            const { message } = e as Error;
+            return res.status(400).json({
+              error: true,
+              message,
+            });
+          }
+
+          // Generate password hash
+          const hash = await getPasswordHash(newPassword);
+
+          // This will reject the update if the new username is not unique (except the same user)
+          await prisma.user.update({
+            where: {
+              id: existingChapterUser.userId,
+            },
+            data: {
+              username: newUsername,
+              hash,
+            },
+          });
+
+          return res.status(200).json({
+            error: false,
+            message: 'Successfully updated credentials for the chapter user',
+          });
+        }
+
+        return res.status(400).json({
+          error: true,
+          message: `No chapter user found for id: ${userId}`,
+        });
+      } catch (e) {
+        return serverErrorHandler(e, res);
+      }
+
+    default:
+      res.setHeader('Allow', ['PUT']);
+      return res
+        .status(405)
+        .json({ error: true, message: `Method ${req.method} Not Allowed` });
+  }
+}
+
+export default withAdminRequestSession(handler);

--- a/src/utils/middlewares/auth.ts
+++ b/src/utils/middlewares/auth.ts
@@ -1,0 +1,24 @@
+import { NextApiResponse } from 'next';
+import { Handler } from 'next-iron-session';
+import { SessionAdminUser } from '@/pages/api/admin/login';
+import { NextIronRequest, withSession } from '../session';
+
+/**
+ * Helper function for protecting Admin only API routes.
+ * Returns 401 response if unauthenticated or unauthorized.
+ */
+export function withAdminRequestSession(
+  handler: Handler<NextIronRequest, NextApiResponse>,
+) {
+  return withSession(async (req, res) => {
+    const user = req.session.get('user') as SessionAdminUser;
+    if (user && user.isLoggedIn && user.admin) {
+      await handler(req, res);
+    } else {
+      res.status(401).json({
+        isLoggedIn: false,
+        message: 'Please login as an admin to access the resource',
+      });
+    }
+  });
+}

--- a/src/utils/prisma-validation.ts
+++ b/src/utils/prisma-validation.ts
@@ -2,7 +2,28 @@ import { Prisma } from '@prisma/client';
 
 export function validateEmail(email: string | undefined) {
   if (!email || email.trim().length === 0) {
-    throw Error('Please provide a valid email');
+    throw Error('Please provide an email address');
+  }
+
+  // Credits - https://www.regular-expressions.info/email.html
+  const emailRegex =
+    /[a-z0-9!#$%&'*+/=?^_‘{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_‘{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
+  if (!emailRegex.test(email)) {
+    throw Error('Please provided a valid email address');
+  }
+}
+
+export function validateUsername(username: string | undefined) {
+  // TODO: Add constraints to username as required
+  if (!username || username.trim().length === 0) {
+    throw Error('Please provide a valid username');
+  }
+}
+
+export function validatePassword(password: string | undefined) {
+  // TODO: Add constraints to password as required
+  if (!password || password.trim().length === 0) {
+    throw Error('Please provide a valid password');
   }
 }
 
@@ -54,13 +75,8 @@ export function validateNewUserInput(user: Prisma.UserCreateInput | undefined) {
   if (user) {
     const { username, hash } = user;
 
-    if (!username || username.trim().length === 0) {
-      throw Error('Please provide a valid username for the user');
-    }
-
-    if (!hash || hash.trim().length === 0) {
-      throw Error('Please provide a valid password for the user');
-    }
+    validateUsername(username);
+    validatePassword(hash);
   } else {
     throw Error('Please provide a valid chapter user');
   }


### PR DESCRIPTION
### Description
Add a new endpoint `PUT /api/chapters/users/:userId` that updates the user credentials for the chapter user specified by the chapter user-id - `:userId`. This endpoint is accessible only to admins.

The request should contain a username and password that represents the new credentials.
```json
PUT /api/chapters/users/1
{
  "newUsername": "dwight.schrute",
  "newPassword": "000000"
}
```

**Related Issues/PRs:** 

- Closes #45


### Test Plan
Existing user
- Login as an admin.
- Send a `PUT` request to an existing chapter user with new credentials (unique username)
- Check Prisma to see the credentials were successfully updated.

Duplicate Username
- Login as an admin.
- Send a `PUT` request to an existing chapter user with new credentials but an already existing username (not for the same user)
- The request should throw an error.
- Check Prisma to ensure the credentials were not updated.

Unauthenticated Request
- Logout as an admin.
- Send a `PUT` request to an existing chapter user with new credentials (unique username)
- The request should throw an error.
- Check Prisma to see the credentials were not updated.

