### PR TITLE
Show chapter details

### DIFF
--- a/src/components/ChapterCard.tsx
+++ b/src/components/ChapterCard.tsx
@@ -1,0 +1,32 @@
+// This is a dummy card to test functionality to view/edit/delete chapter.
+
+import { Box } from '@chakra-ui/react';
+import React, { useContext } from 'react';
+import { ChapterModalContext } from '@/providers/ChapterModalProvider';
+
+// Issue #42 handles the adding chapter cards to match the mockups
+function ChapterCard() {
+  const { onOpen, setModalState, setActiveChapter } =
+    useContext(ChapterModalContext);
+
+  const onChapterClick = (id: number) => {
+    setActiveChapter(id);
+    // setModalState(ModalState.ViewChapter);
+    onOpen();
+  };
+
+  return (
+    <Box
+      onClick={() => onChapterClick(1)}
+      boxShadow="lg"
+      borderRadius="md"
+      borderWidth="1px"
+      cursor="pointer"
+      py="5"
+    >
+      Chapter 1
+    </Box>
+  );
+}
+
+export default ChapterCard;

--- a/src/components/ChapterCard.tsx
+++ b/src/components/ChapterCard.tsx
@@ -2,29 +2,37 @@
 
 import { Box } from '@chakra-ui/react';
 import React, { useContext } from 'react';
-import { ChapterModalContext } from '@/providers/ChapterModalProvider';
+import { Chapter } from '@prisma/client';
+import {
+  ChapterModalContext,
+  ModalState,
+} from '@/providers/ChapterModalProvider';
+
+interface ChapterCardProps {
+  chapter: Chapter;
+}
 
 // Issue #42 handles the adding chapter cards to match the mockups
-function ChapterCard() {
+function ChapterCard({ chapter }: ChapterCardProps) {
   const { onOpen, setModalState, setActiveChapter } =
     useContext(ChapterModalContext);
 
-  const onChapterClick = (id: number) => {
-    setActiveChapter(id);
-    // setModalState(ModalState.ViewChapter);
+  const onChapterClick = () => {
+    setActiveChapter(chapter.id);
+    setModalState(ModalState.ViewChapter);
     onOpen();
   };
 
   return (
     <Box
-      onClick={() => onChapterClick(1)}
+      onClick={() => onChapterClick()}
       boxShadow="lg"
       borderRadius="md"
       borderWidth="1px"
       cursor="pointer"
       py="5"
     >
-      Chapter 1
+      {chapter.chapterName}
     </Box>
   );
 }

--- a/src/components/chapter-modals/ChapterModalController.tsx
+++ b/src/components/chapter-modals/ChapterModalController.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { Modal, ModalOverlay } from '@chakra-ui/react';
 import { ChapterModalContext } from '@/providers/ChapterModalProvider';
 import NewChapterModal from './NewChapterModal';
+import ViewChapterModal from './ViewChapterModal';
 
 // eslint-disable-next-line no-shadow
 export enum ModalState {
@@ -19,6 +20,8 @@ const ChapterModalContent = ({ state }: ChapterModalContentProps) => {
   switch (state) {
     case ModalState.NewChapter:
       return <NewChapterModal />;
+    case ModalState.ViewChapter:
+      return <ViewChapterModal />;
     default:
       return <h1>No Modal created for this state</h1>;
   }

--- a/src/components/chapter-modals/NewChapterModal.tsx
+++ b/src/components/chapter-modals/NewChapterModal.tsx
@@ -17,6 +17,7 @@ import { emailRegex } from '@/utils/prisma-validation';
 import { ChaptersContext } from '@/providers/ChaptersProvider';
 import { PostChapterResponse } from '@/pages/api/chapters';
 import { ErrorResponse } from '@/utils/error';
+import { ChapterDetails } from '@/pages/api/chapters/[chapterId]';
 
 interface NewChapterFormBody {
   chapterName: string;
@@ -59,7 +60,7 @@ const createNewChapter = async (data: NewChapterFormBody) => {
     throw Error(responseJson.message);
   }
 
-  return responseJson.chapter;
+  return responseJson.chapter as ChapterDetails;
 };
 
 const NewChapterModal = () => {

--- a/src/components/chapter-modals/NewChapterModal.tsx
+++ b/src/components/chapter-modals/NewChapterModal.tsx
@@ -14,6 +14,9 @@ import {
 import { useForm } from 'react-hook-form';
 import { ChapterModalContext } from '@/providers/ChapterModalProvider';
 import { emailRegex } from '@/utils/prisma-validation';
+import { ChaptersContext } from '@/providers/ChaptersProvider';
+import { PostChapterResponse } from '@/pages/api/chapters';
+import { ErrorResponse } from '@/utils/error';
 
 interface NewChapterFormBody {
   chapterName: string;
@@ -46,7 +49,8 @@ const createNewChapter = async (data: NewChapterFormBody) => {
     },
   });
 
-  const responseJson = await response.json();
+  const responseJson = (await response.json()) as PostChapterResponse &
+    ErrorResponse;
   if (response.status !== 200) {
     throw Error(responseJson.message);
   }
@@ -55,7 +59,7 @@ const createNewChapter = async (data: NewChapterFormBody) => {
     throw Error(responseJson.message);
   }
 
-  return responseJson;
+  return responseJson.chapter;
 };
 
 const NewChapterModal = () => {
@@ -66,12 +70,14 @@ const NewChapterModal = () => {
   } = useForm();
 
   const { onClose } = useContext(ChapterModalContext);
+  const { upsertChapter } = useContext(ChaptersContext);
 
   const onSubmit = async (x: NewChapterFormBody) => {
     try {
-      const response = await createNewChapter(x);
+      const newChapter = await createNewChapter(x);
+      upsertChapter(newChapter);
       onClose();
-      alert(response.message);
+      alert(`Sucessfully added new chapter: ${newChapter.id}`);
     } catch (e) {
       alert(e);
     }

--- a/src/components/chapter-modals/ViewChapterModal.tsx
+++ b/src/components/chapter-modals/ViewChapterModal.tsx
@@ -14,9 +14,9 @@ import {
   Divider,
   SimpleGrid,
 } from '@chakra-ui/react';
-import { Chapter, User } from '@prisma/client';
 import { ChapterModalContext } from '@/providers/ChapterModalProvider';
 import { ChaptersContext } from '@/providers/ChaptersProvider';
+import { ChapterDetails } from '@/pages/api/chapters/[chapterId]';
 
 const getChapterDetails = async (id: number) => {
   const response = await fetch(`/api/chapters/${id}`, {
@@ -35,18 +35,14 @@ const getChapterDetails = async (id: number) => {
     throw Error(responseJson.message);
   }
 
-  return responseJson.chapter as Chapter;
+  return responseJson.chapter as ChapterDetails;
 };
 
 interface ChapterDetailsProps {
-  chapter: Chapter;
+  chapter: ChapterDetails;
 }
 
-interface UserDetailsProps {
-  user?: User;
-}
-
-const ChapterDetails = ({ chapter }: ChapterDetailsProps) => (
+const ChapterInformation = ({ chapter }: ChapterDetailsProps) => (
   <Box>
     <Heading size="md" mb="2">
       Contact Information
@@ -71,7 +67,7 @@ const ChapterDetails = ({ chapter }: ChapterDetailsProps) => (
   </Box>
 );
 
-const UserDetails = ({ user }: UserDetailsProps) => (
+const UserInformation = ({ chapter }: ChapterDetailsProps) => (
   <Box>
     <Heading size="md" mb="2">
       Login Credentials
@@ -81,7 +77,7 @@ const UserDetails = ({ user }: UserDetailsProps) => (
 
     <Box my="2">
       <Heading size="xs">Username</Heading>
-      <Text>{user?.username || 'username'}</Text>
+      <Text>{chapter?.chapterUser?.user?.username}</Text>
     </Box>
   </Box>
 );
@@ -91,7 +87,9 @@ const ViewChapterModal = () => {
   const { chapters, upsertChapter } = useContext(ChaptersContext);
 
   const [loading, setLoading] = useState(true);
-  const [currentChapter, setCurrentChapter] = useState<Chapter | null>(null);
+  const [currentChapter, setCurrentChapter] = useState<ChapterDetails | null>(
+    null,
+  );
 
   useEffect(() => {
     if (activeChapter >= 0) {
@@ -128,10 +126,12 @@ const ViewChapterModal = () => {
       <ModalCloseButton />
       <ModalBody pb="5">
         {loading && <Spinner />}
-        <SimpleGrid columns={{ base: 1, md: 2 }} spacing="5">
-          {currentChapter && <ChapterDetails chapter={currentChapter} />}
-          {currentChapter && <UserDetails />}
-        </SimpleGrid>
+        {currentChapter && (
+          <SimpleGrid columns={{ base: 1, md: 2 }} spacing="5">
+            <ChapterInformation chapter={currentChapter} />
+            <UserInformation chapter={currentChapter} />
+          </SimpleGrid>
+        )}
         <Divider my="5" />
         <Flex>
           <Button

--- a/src/components/chapter-modals/ViewChapterModal.tsx
+++ b/src/components/chapter-modals/ViewChapterModal.tsx
@@ -12,8 +12,9 @@ import {
   Flex,
   Spacer,
   Divider,
+  SimpleGrid,
 } from '@chakra-ui/react';
-import { Chapter } from '@prisma/client';
+import { Chapter, User } from '@prisma/client';
 import { ChapterModalContext } from '@/providers/ChapterModalProvider';
 import { ChaptersContext } from '@/providers/ChaptersProvider';
 
@@ -41,15 +42,47 @@ interface ChapterDetailsProps {
   chapter: Chapter;
 }
 
+interface UserDetailsProps {
+  user?: User;
+}
+
 const ChapterDetails = ({ chapter }: ChapterDetailsProps) => (
   <Box>
     <Heading size="md" mb="2">
       Contact Information
     </Heading>
 
-    <Text>{chapter.contactName}</Text>
-    <Text>{chapter.email}</Text>
-    <Text>{chapter.phoneNumber}</Text>
+    <Divider />
+
+    <Box my="2">
+      <Heading size="xs">Contact Name</Heading>
+      <Text>{chapter.contactName}</Text>
+    </Box>
+
+    <Box my="2">
+      <Heading size="xs">Email</Heading>
+      <Text>{chapter.email}</Text>
+    </Box>
+
+    <Box my="2">
+      <Heading size="xs">Phone Number</Heading>
+      <Text>{chapter.phoneNumber}</Text>
+    </Box>
+  </Box>
+);
+
+const UserDetails = ({ user }: UserDetailsProps) => (
+  <Box>
+    <Heading size="md" mb="2">
+      Login Credentials
+    </Heading>
+
+    <Divider />
+
+    <Box my="2">
+      <Heading size="xs">Username</Heading>
+      <Text>{user?.username || 'username'}</Text>
+    </Box>
   </Box>
 );
 
@@ -95,7 +128,10 @@ const ViewChapterModal = () => {
       <ModalCloseButton />
       <ModalBody pb="5">
         {loading && <Spinner />}
-        {currentChapter && <ChapterDetails chapter={currentChapter} />}
+        <SimpleGrid columns={{ base: 1, md: 2 }} spacing="5">
+          {currentChapter && <ChapterDetails chapter={currentChapter} />}
+          {currentChapter && <UserDetails />}
+        </SimpleGrid>
         <Divider my="5" />
         <Flex>
           <Button

--- a/src/components/chapter-modals/ViewChapterModal.tsx
+++ b/src/components/chapter-modals/ViewChapterModal.tsx
@@ -1,0 +1,123 @@
+import React, { useContext, useEffect, useState } from 'react';
+import {
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  Spinner,
+  Heading,
+  Box,
+  Button,
+  Text,
+  Flex,
+  Spacer,
+  Divider,
+} from '@chakra-ui/react';
+import { Chapter } from '@prisma/client';
+import { ChapterModalContext } from '@/providers/ChapterModalProvider';
+import { ChaptersContext } from '@/providers/ChaptersProvider';
+
+const getChapterDetails = async (id: number) => {
+  const response = await fetch(`/api/chapters/${id}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const responseJson = await response.json();
+  if (response.status !== 200) {
+    throw Error(responseJson.message);
+  }
+
+  if (responseJson.error) {
+    throw Error(responseJson.message);
+  }
+
+  return responseJson.chapter as Chapter;
+};
+
+interface ChapterDetailsProps {
+  chapter: Chapter;
+}
+
+const ChapterDetails = ({ chapter }: ChapterDetailsProps) => (
+  <Box>
+    <Heading size="md" mb="2">
+      Contact Information
+    </Heading>
+
+    <Text>{chapter.contactName}</Text>
+    <Text>{chapter.email}</Text>
+    <Text>{chapter.phoneNumber}</Text>
+  </Box>
+);
+
+const ViewChapterModal = () => {
+  const { onClose, activeChapter } = useContext(ChapterModalContext);
+  const { chapters, upsertChapter } = useContext(ChaptersContext);
+
+  const [loading, setLoading] = useState(true);
+  const [currentChapter, setCurrentChapter] = useState<Chapter | null>(null);
+
+  useEffect(() => {
+    if (activeChapter >= 0) {
+      setLoading(true);
+      setCurrentChapter(null);
+      if (activeChapter in chapters) {
+        setCurrentChapter(chapters[activeChapter]);
+        setLoading(false);
+      } else {
+        getChapterDetails(activeChapter)
+          .then((chapter) => {
+            upsertChapter(chapter);
+            setCurrentChapter(chapter);
+          })
+          .catch((err) => alert(err))
+          .finally(() => setLoading(false));
+      }
+    }
+  }, [activeChapter, chapters, upsertChapter]);
+
+  const onEditClick = () => {
+    // TODO - Open Edit Modal for the active chapter
+    onClose();
+  };
+
+  const onDeleteClick = () => {
+    // TODO - Open delete confirmation modal for the active chapter
+    onClose();
+  };
+
+  return (
+    <ModalContent>
+      <ModalHeader>{currentChapter?.chapterName || 'Chapter'}</ModalHeader>
+      <ModalCloseButton />
+      <ModalBody pb="5">
+        {loading && <Spinner />}
+        {currentChapter && <ChapterDetails chapter={currentChapter} />}
+        <Divider my="5" />
+        <Flex>
+          <Button
+            colorScheme="blue"
+            disabled={!currentChapter}
+            onClick={onEditClick}
+          >
+            Edit Chapter
+          </Button>
+          <Spacer />
+          <Button
+            variant="outline"
+            colorScheme="blue"
+            disabled={!currentChapter}
+            onClick={onDeleteClick}
+          >
+            Delete Chapter
+          </Button>
+        </Flex>
+      </ModalBody>
+    </ModalContent>
+  );
+};
+
+export default ViewChapterModal;

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -48,7 +48,7 @@ function ChapterCardsGrid() {
   const { chapters } = useContext(ChaptersContext);
 
   return (
-    <SimpleGrid columns={[1, 2, 4]} my="5" spacing="5">
+    <SimpleGrid columns={{ base: 1, md: 2, lg: 4 }} my="5" spacing="5">
       {Object.values(chapters).map((x) => (
         <ChapterCard chapter={x} key={x.id} />
       ))}

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import { GetServerSideProps } from 'next';
 import {
-  Container,
+  SimpleGrid,
   Heading,
   Text,
   Divider,
@@ -20,6 +20,7 @@ import {
   ChapterModalContext,
   ChapterModalProvider,
 } from '@/providers/ChapterModalProvider';
+import ChapterCard from '@/components/ChapterCard';
 
 interface AdminDashboardProps {
   user: SessionAdminUser;
@@ -49,6 +50,10 @@ export default function AdminDashboardPage({ user }: AdminDashboardProps) {
           <Spacer />
           <AddNewChapterButton />
         </Flex>
+
+        <SimpleGrid columns={[1, 2, 4]} my="5">
+          <ChapterCard />
+        </SimpleGrid>
 
         <ChapterModalController />
       </Box>

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -26,10 +26,11 @@ import {
   ChaptersContext,
   ChaptersProvider,
 } from '@/providers/ChaptersProvider';
+import { ChapterDetails } from '../api/chapters/[chapterId]';
 
 interface AdminDashboardProps {
   user: SessionAdminUser;
-  chapters: Chapter[];
+  chapters: ChapterDetails[];
   chapterError?: string;
 }
 
@@ -94,7 +95,15 @@ export const getServerSideProps: GetServerSideProps<AdminDashboardProps> =
     let chapterError = '';
     try {
       const prisma = new PrismaClient();
-      chapters = await prisma.chapter.findMany();
+      chapters = await prisma.chapter.findMany({
+        include: {
+          chapterUser: {
+            include: {
+              user: true,
+            },
+          },
+        },
+      });
     } catch (e) {
       chapters = [];
       chapterError = 'Failed to retrieve the chapters. Please try again later';

--- a/src/pages/api/chapters/[chapterId].ts
+++ b/src/pages/api/chapters/[chapterId].ts
@@ -1,4 +1,10 @@
-import { PrismaClient, Prisma, Chapter } from '@prisma/client';
+import {
+  PrismaClient,
+  Prisma,
+  Chapter,
+  ChapterUser,
+  User,
+} from '@prisma/client';
 import type { NextApiResponse } from 'next';
 
 import { SessionChapterUser } from './login';
@@ -13,15 +19,16 @@ interface ChapterUpdateBody {
   updatedChapter: Prisma.ChapterCreateInput;
 }
 
-export type ChapterInfo = {
-  email: string;
-  contactName: string;
-  chapterName: string;
-  phoneNumber: string | null;
+export type ChapterDetails = Chapter & {
+  chapterUser:
+    | (ChapterUser & {
+        user: User;
+      })
+    | null;
 };
 
 export type ChapterResponse = {
-  chapter: Chapter;
+  chapter: Chapter | ChapterDetails;
 };
 
 async function handler(
@@ -183,6 +190,13 @@ async function handler(
           const existingChapter = await prisma.chapter.findUnique({
             where: {
               id: parsedChapterId,
+            },
+            include: {
+              chapterUser: {
+                include: {
+                  user: true,
+                },
+              },
             },
           });
 

--- a/src/pages/api/chapters/[chapterId].ts
+++ b/src/pages/api/chapters/[chapterId].ts
@@ -42,7 +42,7 @@ async function handler(
 
   const parsedChapterId = Number(chapterId);
 
-  // Check if admin or if the current chapter user match the chapter they want to update
+  // Check if admin or if the current chapter user match the chapter they want to access
   const isAuthorizedUser =
     user.admin !== undefined ||
     (user.chapterUser && user.chapterUser.chapterId === parsedChapterId);

--- a/src/pages/api/chapters/[chapterId].ts
+++ b/src/pages/api/chapters/[chapterId].ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Prisma } from '@prisma/client';
+import { PrismaClient, Prisma, Chapter } from '@prisma/client';
 import type { NextApiResponse } from 'next';
 
 import { SessionChapterUser } from './login';
@@ -20,9 +20,13 @@ export type ChapterInfo = {
   phoneNumber: string | null;
 };
 
+export type ChapterResponse = {
+  chapter: Chapter;
+};
+
 async function handler(
   req: NextIronRequest,
-  res: NextApiResponse<ErrorResponse | ChapterInfo>,
+  res: NextApiResponse<ErrorResponse | ChapterResponse>,
 ) {
   const { chapterId } = req.query;
 
@@ -39,13 +43,13 @@ async function handler(
   const parsedChapterId = Number(chapterId);
 
   // Check if admin or if the current chapter user match the chapter they want to update
-  const isUpdateAuthorized =
+  const isAuthorizedUser =
     user.admin !== undefined ||
     (user.chapterUser && user.chapterUser.chapterId === parsedChapterId);
 
   switch (req.method) {
     case 'PUT':
-      if (!isUpdateAuthorized) {
+      if (!isAuthorizedUser) {
         return res.status(401).json({
           message: 'Please login as an authorized user to access the resource',
           error: true,
@@ -175,7 +179,7 @@ async function handler(
         const prisma = new PrismaClient();
 
         // checks to see if the user is part of the chapter
-        if (isUpdateAuthorized) {
+        if (isAuthorizedUser) {
           const existingChapter = await prisma.chapter.findUnique({
             where: {
               id: parsedChapterId,
@@ -190,14 +194,8 @@ async function handler(
             });
           }
 
-          // return information if they are
-          const { contactName, email, chapterName, phoneNumber } =
-            existingChapter;
           return res.status(200).json({
-            contactName,
-            email,
-            chapterName,
-            phoneNumber,
+            chapter: existingChapter,
           });
         }
         return res.status(400).json({

--- a/src/pages/api/chapters/index.ts
+++ b/src/pages/api/chapters/index.ts
@@ -9,8 +9,12 @@ import {
   validateNewUserInput,
 } from '@/utils/prisma-validation';
 
-type DataResponse = {
+export type GetChapterResponse = {
   chapters: Chapter[];
+};
+
+export type PostChapterResponse = {
+  chapter: Chapter;
 };
 
 export type NewChapterInputBody = {
@@ -20,7 +24,9 @@ export type NewChapterInputBody = {
 
 async function handler(
   req: NextIronRequest,
-  res: NextApiResponse<DataResponse | ErrorResponse>,
+  res: NextApiResponse<
+    GetChapterResponse | PostChapterResponse | ErrorResponse
+  >,
 ) {
   switch (req.method) {
     case 'GET':
@@ -90,8 +96,7 @@ async function handler(
         });
 
         return res.status(200).json({
-          error: false,
-          message: `Successfully created a chapter: ${createdChapter.id}`,
+          chapter: createdChapter,
         });
       } catch (e) {
         return serverErrorHandler(e, res);

--- a/src/providers/ChapterModalProvider.tsx
+++ b/src/providers/ChapterModalProvider.tsx
@@ -25,7 +25,7 @@ export interface ChapterModalProviderProps {
 
 export const ChapterModalContext = createContext<ChapterModalContextProps>({
   isOpen: false,
-  activeChapter: 0,
+  activeChapter: -1,
   currentModalState: ModalState.NewChapter,
   onClose: () => {
     throw new Error('Method not implemented');

--- a/src/providers/ChaptersProvider.tsx
+++ b/src/providers/ChaptersProvider.tsx
@@ -1,4 +1,4 @@
-import { Chapter, User } from '@prisma/client';
+import { Chapter } from '@prisma/client';
 import { createContext, useEffect, useState } from 'react';
 
 export interface ChaptersContextProps {

--- a/src/providers/ChaptersProvider.tsx
+++ b/src/providers/ChaptersProvider.tsx
@@ -1,15 +1,15 @@
-import { Chapter } from '@prisma/client';
 import { createContext, useEffect, useState } from 'react';
+import { ChapterDetails } from '@/pages/api/chapters/[chapterId]';
 
 export interface ChaptersContextProps {
-  chapters: Record<number, Chapter>;
-  upsertChapter: (data: Chapter) => void;
+  chapters: Record<number, ChapterDetails>;
+  upsertChapter: (data: ChapterDetails) => void;
   removeChapter: (id: number) => void;
 }
 
 export interface ChaptersProviderProps {
   children: JSX.Element;
-  initChapters: Chapter[];
+  initChapters: ChapterDetails[];
 }
 
 export const ChaptersContext = createContext<ChaptersContextProps>({
@@ -17,7 +17,7 @@ export const ChaptersContext = createContext<ChaptersContextProps>({
   removeChapter: (id: number) => {
     throw Error('Method not implemented');
   },
-  upsertChapter: (x: Chapter) => {
+  upsertChapter: (x: ChapterDetails) => {
     throw Error('Method not implemented');
   },
 });
@@ -26,10 +26,10 @@ export const ChaptersProvider = ({
   children,
   initChapters,
 }: ChaptersProviderProps) => {
-  const [chapters, setChapters] = useState<Record<number, Chapter>>({});
+  const [chapters, setChapters] = useState<Record<number, ChapterDetails>>({});
 
   useEffect(() => {
-    const parsedChapters: Record<number, Chapter> = {};
+    const parsedChapters: Record<number, ChapterDetails> = {};
     for (let i = 0; i < initChapters.length; i += 1) {
       const currentChapter = initChapters[i];
       parsedChapters[currentChapter.id] = currentChapter;
@@ -43,7 +43,7 @@ export const ChaptersProvider = ({
     setChapters(newChapters);
   };
 
-  const upsertChapter = (addChapter: Chapter) => {
+  const upsertChapter = (addChapter: ChapterDetails) => {
     const { id } = addChapter;
     setChapters({
       ...chapters,

--- a/src/providers/ChaptersProvider.tsx
+++ b/src/providers/ChaptersProvider.tsx
@@ -38,9 +38,9 @@ export const ChaptersProvider = ({
   }, [initChapters]);
 
   const removeChapter = (id: number) => {
-    if (id in chapters) {
-      delete chapters[id];
-    }
+    const newChapters = { ...chapters };
+    delete newChapters[id];
+    setChapters(newChapters);
   };
 
   const upsertChapter = (addChapter: Chapter) => {

--- a/src/providers/ChaptersProvider.tsx
+++ b/src/providers/ChaptersProvider.tsx
@@ -1,0 +1,65 @@
+import { Chapter, User } from '@prisma/client';
+import { createContext, useEffect, useState } from 'react';
+
+export interface ChaptersContextProps {
+  chapters: Record<number, Chapter>;
+  upsertChapter: (data: Chapter) => void;
+  removeChapter: (id: number) => void;
+}
+
+export interface ChaptersProviderProps {
+  children: JSX.Element;
+  initChapters: Chapter[];
+}
+
+export const ChaptersContext = createContext<ChaptersContextProps>({
+  chapters: {},
+  removeChapter: (id: number) => {
+    throw Error('Method not implemented');
+  },
+  upsertChapter: (x: Chapter) => {
+    throw Error('Method not implemented');
+  },
+});
+
+export const ChaptersProvider = ({
+  children,
+  initChapters,
+}: ChaptersProviderProps) => {
+  const [chapters, setChapters] = useState<Record<number, Chapter>>({});
+
+  useEffect(() => {
+    const parsedChapters: Record<number, Chapter> = {};
+    for (let i = 0; i < initChapters.length; i += 1) {
+      const currentChapter = initChapters[i];
+      parsedChapters[currentChapter.id] = currentChapter;
+    }
+    setChapters(parsedChapters);
+  }, [initChapters]);
+
+  const removeChapter = (id: number) => {
+    if (id in chapters) {
+      delete chapters[id];
+    }
+  };
+
+  const upsertChapter = (addChapter: Chapter) => {
+    const { id } = addChapter;
+    setChapters({
+      ...chapters,
+      [id]: addChapter,
+    });
+  };
+
+  return (
+    <ChaptersContext.Provider
+      value={{
+        chapters,
+        removeChapter,
+        upsertChapter,
+      }}
+    >
+      {children}
+    </ChaptersContext.Provider>
+  );
+};


### PR DESCRIPTION
### Description
This PR finds all the chapters on the server-side and renders a basic Chapter Card on the admin dashboard (#42 will handle making it pretty). On clicking the card, it will display the basic information for the chapter.

Similarly, `ChapterContext` has been created to manage chapters shown in the admin dashboard. This allows us to easily add and remove cards from the dashboard when new chapters are created and existing chapters are deleted.

**Note:** There will be follow-up PRs to create edit and delete modals.

**Related Issues/PRs:** 
- #47 

### Test Plan

- Login as an admin user. It should display a dashboard with chapters that is currently in the database.
![image](https://user-images.githubusercontent.com/43834826/139558287-745990de-91be-4ec3-b0e1-78713c27d27d.png)

- Follow the test plan for #68 to add a new chapter. On successful creation, a new card will be added to the dashboard.

- Click on any existing card. It should display detailed information about that chapter.
![image](https://user-images.githubusercontent.com/43834826/139558342-f2768112-a936-4dda-a70c-1d5d799087f6.png)


