### PR TITLE
Modal to delete chapter

### DIFF
--- a/src/components/chapter-modals/ChapterModalController.tsx
+++ b/src/components/chapter-modals/ChapterModalController.tsx
@@ -1,8 +1,16 @@
 import React, { useContext } from 'react';
-import { Modal, ModalOverlay } from '@chakra-ui/react';
+import {
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react';
 import { ChapterModalContext } from '@/providers/ChapterModalProvider';
 import NewChapterModal from './NewChapterModal';
 import ViewChapterModal from './ViewChapterModal';
+import DeleteChapterModal from './DeleteChapterModal';
 
 // eslint-disable-next-line no-shadow
 export enum ModalState {
@@ -22,8 +30,18 @@ const ChapterModalContent = ({ state }: ChapterModalContentProps) => {
       return <NewChapterModal />;
     case ModalState.ViewChapter:
       return <ViewChapterModal />;
+    case ModalState.DeleteChapter:
+      return <DeleteChapterModal />;
     default:
-      return <h1>No Modal created for this state</h1>;
+      return (
+        <ModalContent>
+          <ModalHeader>Chapter</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb="5">
+            <h1>No Modal created for this action</h1>
+          </ModalBody>
+        </ModalContent>
+      );
   }
 };
 

--- a/src/components/chapter-modals/DeleteChapterModal.tsx
+++ b/src/components/chapter-modals/DeleteChapterModal.tsx
@@ -43,12 +43,13 @@ const DeleteChapterModal = () => {
   const [loading, setLoading] = useState(false);
 
   const onConfirmation = () => {
-    // TODO - Open Edit Modal for the active chapter
     setLoading(true);
     deleteChapter(activeChapter)
       .then(() => {
-        setActiveChapter(-1);
         onClose();
+        setModalState(ModalState.NewChapter);
+        removeChapter(activeChapter);
+        setActiveChapter(-1);
       })
       .catch((err) => {
         alert(err);
@@ -74,11 +75,11 @@ const DeleteChapterModal = () => {
           Are you sure?
         </Text>
         <Text color="gray.500">This action will delete chapter</Text>
-        <Text fontSize="3xl">{chapterToDelete.chapterName}</Text>
+        <Text fontSize="3xl">{chapterToDelete?.chapterName}</Text>
         <Text color="gray.500">This action cannot be undone</Text>
         <Divider my="5" />
         <Flex>
-          <Button colorScheme="red" disabled={loading}>
+          <Button colorScheme="red" disabled={loading} onClick={onConfirmation}>
             Delete
           </Button>
           <Spacer />

--- a/src/components/chapter-modals/DeleteChapterModal.tsx
+++ b/src/components/chapter-modals/DeleteChapterModal.tsx
@@ -1,0 +1,94 @@
+import React, { useContext, useState } from 'react';
+import {
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  Button,
+  Text,
+  Flex,
+  Spacer,
+  Divider,
+} from '@chakra-ui/react';
+import {
+  ChapterModalContext,
+  ModalState,
+} from '@/providers/ChapterModalProvider';
+import { ChaptersContext } from '@/providers/ChaptersProvider';
+
+const deleteChapter = async (id: number) => {
+  const response = await fetch(`/api/chapters/${id}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const responseJson = await response.json();
+  if (response.status !== 200) {
+    throw Error(responseJson.message);
+  }
+
+  if (responseJson.error) {
+    throw Error(responseJson.message);
+  }
+
+  return responseJson;
+};
+
+const DeleteChapterModal = () => {
+  const { onClose, activeChapter, setModalState, setActiveChapter } =
+    useContext(ChapterModalContext);
+  const { chapters, removeChapter } = useContext(ChaptersContext);
+
+  const [loading, setLoading] = useState(false);
+
+  const onConfirmation = () => {
+    // TODO - Open Edit Modal for the active chapter
+    setLoading(true);
+    deleteChapter(activeChapter)
+      .then(() => {
+        setActiveChapter(-1);
+        onClose();
+      })
+      .catch((err) => {
+        alert(err);
+        setModalState(ModalState.ViewChapter);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  const chapterToDelete = chapters[activeChapter];
+
+  const onCancel = () => {
+    setModalState(ModalState.ViewChapter);
+  };
+
+  return (
+    <ModalContent>
+      <ModalCloseButton />
+      <ModalBody pb="5" mt="5" textAlign="center">
+        {/* Add icon to bring attention to user */}
+        <Text fontSize="4xl" my="5">
+          Are you sure?
+        </Text>
+        <Text color="gray.500">This action will delete chapter</Text>
+        <Text fontSize="3xl">{chapterToDelete.chapterName}</Text>
+        <Text color="gray.500">This action cannot be undone</Text>
+        <Divider my="5" />
+        <Flex>
+          <Button colorScheme="red" disabled={loading}>
+            Delete
+          </Button>
+          <Spacer />
+          <Button disabled={loading} onClick={onCancel}>
+            Cancel
+          </Button>
+        </Flex>
+      </ModalBody>
+    </ModalContent>
+  );
+};
+
+export default DeleteChapterModal;

--- a/src/components/chapter-modals/DeleteChapterModal.tsx
+++ b/src/components/chapter-modals/DeleteChapterModal.tsx
@@ -79,7 +79,11 @@ const DeleteChapterModal = () => {
         <Text color="gray.500">This action cannot be undone</Text>
         <Divider my="5" />
         <Flex>
-          <Button colorScheme="red" disabled={loading} onClick={onConfirmation}>
+          <Button
+            colorScheme="red"
+            isLoading={loading}
+            onClick={onConfirmation}
+          >
             Delete
           </Button>
           <Spacer />

--- a/src/components/chapter-modals/ViewChapterModal.tsx
+++ b/src/components/chapter-modals/ViewChapterModal.tsx
@@ -14,7 +14,10 @@ import {
   Divider,
 } from '@chakra-ui/react';
 import { Chapter } from '@prisma/client';
-import { ChapterModalContext } from '@/providers/ChapterModalProvider';
+import {
+  ChapterModalContext,
+  ModalState,
+} from '@/providers/ChapterModalProvider';
 import { ChaptersContext } from '@/providers/ChaptersProvider';
 
 const getChapterDetails = async (id: number) => {
@@ -54,7 +57,8 @@ const ChapterDetails = ({ chapter }: ChapterDetailsProps) => (
 );
 
 const ViewChapterModal = () => {
-  const { onClose, activeChapter } = useContext(ChapterModalContext);
+  const { onClose, activeChapter, setModalState } =
+    useContext(ChapterModalContext);
   const { chapters, upsertChapter } = useContext(ChaptersContext);
 
   const [loading, setLoading] = useState(true);
@@ -85,8 +89,7 @@ const ViewChapterModal = () => {
   };
 
   const onDeleteClick = () => {
-    // TODO - Open delete confirmation modal for the active chapter
-    onClose();
+    setModalState(ModalState.DeleteChapter);
   };
 
   return (

--- a/src/providers/ChaptersProvider.tsx
+++ b/src/providers/ChaptersProvider.tsx
@@ -38,9 +38,9 @@ export const ChaptersProvider = ({
   }, [initChapters]);
 
   const removeChapter = (id: number) => {
-    if (id in chapters) {
-      delete chapters[id];
-    }
+    const newChapters = { ...chapters };
+    delete newChapters[id];
+    setChapters(newChapters);
   };
 
   const upsertChapter = (addChapter: Chapter) => {


### PR DESCRIPTION
### Description
This PR allows admins to delete chapters from the admin dashboard.
It uses `ChapterContext` to remove cards when deleted and make appropriate API calls to delete the chapter from the database.

To prevent accidentally deleting a chapter, a confirmation modal will be displayed to the user before the chapter is deleted permanently.
![image](https://user-images.githubusercontent.com/43834826/139774896-9ec936b4-6c1f-491d-b11f-60cbff50fd04.png)

**Related Issues/PRs:** 
- #47

### Test Plan
- Follow the test plans listed in #82
![image](https://user-images.githubusercontent.com/43834826/139775038-c3bc3aef-5bf3-4592-ad7c-c27141c4ca9a.png)

- Click on `Delete Chapter` for a chapter to be deleted.
![image](https://user-images.githubusercontent.com/43834826/139774896-9ec936b4-6c1f-491d-b11f-60cbff50fd04.png)
- Click the `Cancel` button. The user must be redirected to the chapter details modal and the chapters should not be deleted.
- Click the `Delete` button. The chapter should be deleted in the database (verify it in Prisma). The card for the chapter should be removed from the dashboard and the modal should close.


