### PR TITLE
Create Modal to update chapter

### DIFF
--- a/src/components/chapter-modals/ChapterModalController.tsx
+++ b/src/components/chapter-modals/ChapterModalController.tsx
@@ -7,19 +7,14 @@ import {
   ModalHeader,
   ModalOverlay,
 } from '@chakra-ui/react';
-import { ChapterModalContext } from '@/providers/ChapterModalProvider';
+import {
+  ChapterModalContext,
+  ModalState,
+} from '@/providers/ChapterModalProvider';
 import NewChapterModal from './NewChapterModal';
 import ViewChapterModal from './ViewChapterModal';
 import DeleteChapterModal from './DeleteChapterModal';
 import EditChapterModal from './EditChapterModal';
-
-// eslint-disable-next-line no-shadow
-export enum ModalState {
-  NewChapter,
-  ViewChapter,
-  EditChapter,
-  DeleteChapter,
-}
 
 interface ChapterModalContentProps {
   state: ModalState;

--- a/src/components/chapter-modals/ChapterModalController.tsx
+++ b/src/components/chapter-modals/ChapterModalController.tsx
@@ -11,6 +11,7 @@ import { ChapterModalContext } from '@/providers/ChapterModalProvider';
 import NewChapterModal from './NewChapterModal';
 import ViewChapterModal from './ViewChapterModal';
 import DeleteChapterModal from './DeleteChapterModal';
+import EditChapterModal from './EditChapterModal';
 
 // eslint-disable-next-line no-shadow
 export enum ModalState {
@@ -30,6 +31,8 @@ const ChapterModalContent = ({ state }: ChapterModalContentProps) => {
       return <NewChapterModal />;
     case ModalState.ViewChapter:
       return <ViewChapterModal />;
+    case ModalState.EditChapter:
+      return <EditChapterModal />;
     case ModalState.DeleteChapter:
       return <DeleteChapterModal />;
     default:

--- a/src/components/chapter-modals/EditChapterModal.tsx
+++ b/src/components/chapter-modals/EditChapterModal.tsx
@@ -64,7 +64,7 @@ const EditChapterModal = () => {
   const {
     handleSubmit,
     register,
-    formState: { errors, isSubmitting },
+    formState: { errors, isSubmitting, isDirty },
   } = useForm<Chapter>({
     defaultValues: {
       ...chapterToEdit,
@@ -198,6 +198,7 @@ const EditChapterModal = () => {
             <Button
               colorScheme="blue"
               isLoading={isSubmitting || loading}
+              disabled={!isDirty}
               type="submit"
             >
               Save

--- a/src/components/chapter-modals/EditChapterModal.tsx
+++ b/src/components/chapter-modals/EditChapterModal.tsx
@@ -1,0 +1,157 @@
+import React, { useContext, useState } from 'react';
+import {
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  Button,
+  Text,
+  Flex,
+  Spacer,
+  Divider,
+  ModalHeader,
+  FormControl,
+  FormLabel,
+  Input,
+  FormErrorMessage,
+  SimpleGrid,
+} from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { Chapter } from '@prisma/client';
+import {
+  ChapterModalContext,
+  ModalState,
+} from '@/providers/ChapterModalProvider';
+import { ChaptersContext } from '@/providers/ChaptersProvider';
+import { emailRegex } from '@/utils/prisma-validation';
+
+const EditChapterModal = () => {
+  const { activeChapter, setModalState } = useContext(ChapterModalContext);
+  const { chapters } = useContext(ChaptersContext);
+
+  const chapterToEdit = chapters[activeChapter];
+
+  const {
+    handleSubmit,
+    register,
+    formState: { errors, isSubmitting },
+  } = useForm<Chapter>({
+    defaultValues: {
+      ...chapterToEdit,
+    },
+  });
+
+  const onCancel = () => {
+    setModalState(ModalState.ViewChapter);
+  };
+
+  const onSubmit = async (data: Chapter) => {
+    alert('Updating chapter');
+  };
+
+  return (
+    <ModalContent>
+      <ModalHeader>Edit Chapter {chapterToEdit?.chapterName}</ModalHeader>
+      <ModalCloseButton />
+      <ModalBody pb="5" mt="5" textAlign="center">
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <FormControl
+            isRequired
+            isInvalid={errors.chapterName !== undefined}
+            mt={2}
+            mb={2}
+            id="chapterName"
+          >
+            <FormLabel htmlFor="chapterName">Chapter Name</FormLabel>
+            <Input
+              placeholder="Enter Name"
+              {...register('chapterName', {
+                required: 'Chapter Name is required',
+              })}
+              borderColor="black"
+            />
+            <FormErrorMessage>
+              {errors.chapterName && errors.chapterName.message}
+            </FormErrorMessage>
+          </FormControl>
+
+          <FormControl isRequired>
+            <FormLabel>Contact Info</FormLabel>
+          </FormControl>
+          <FormControl
+            isRequired
+            isInvalid={errors.contactName !== undefined}
+            mt={2}
+            mb={2}
+            id="contactName"
+          >
+            <Input
+              placeholder="Contact Name"
+              {...register('contactName', {
+                required: 'Contact name is required',
+              })}
+              borderColor="black"
+            />
+            <FormErrorMessage>
+              {errors.contactName && errors.contactName.message}
+            </FormErrorMessage>
+          </FormControl>
+
+          <SimpleGrid columns={[1, null, 2]} spacing={[0, null, 5]}>
+            <FormControl
+              isRequired
+              isInvalid={errors.email !== undefined}
+              mb={2}
+              id="email"
+            >
+              <Input
+                placeholder="Email"
+                type="email"
+                {...register('email', {
+                  required: 'Email is required',
+                  pattern: {
+                    value: emailRegex,
+                    message: 'Invalid email address',
+                  },
+                })}
+                borderColor="black"
+              />
+              <FormErrorMessage>
+                {errors.email && errors.email.message}
+              </FormErrorMessage>
+            </FormControl>
+
+            <FormControl
+              isInvalid={errors.phoneNumber !== undefined}
+              mb={2}
+              id="phoneNumber"
+            >
+              <Input
+                placeholder="Phone Number (Optional)"
+                type="number"
+                {...register('phoneNumber')}
+                borderColor="black"
+              />
+              <FormErrorMessage>
+                {errors.phoneNumber && errors.phoneNumber.message}
+              </FormErrorMessage>
+            </FormControl>
+          </SimpleGrid>
+
+          <Divider my="5" />
+
+          <Flex>
+            <Button colorScheme="blue" isLoading={isSubmitting} type="submit">
+              Save
+            </Button>
+            <Spacer />
+            <Button disabled={isSubmitting} onClick={onCancel} variant="ghost">
+              Cancel
+            </Button>
+          </Flex>
+        </form>
+      </ModalBody>
+    </ModalContent>
+  );
+};
+
+export default EditChapterModal;

--- a/src/components/chapter-modals/EditConfirmationModal.tsx
+++ b/src/components/chapter-modals/EditConfirmationModal.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {
+  ModalBody,
+  ModalOverlay,
+  ModalCloseButton,
+  ModalContent,
+  Button,
+  Text,
+  Flex,
+  Spacer,
+  Divider,
+  Modal,
+} from '@chakra-ui/react';
+import { Chapter } from '@prisma/client';
+
+interface EditConfirmationProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirmation: () => void;
+  chapter: Chapter;
+}
+
+const EditConfirmationModal = ({
+  isOpen,
+  onClose,
+  chapter,
+  onConfirmation,
+}: EditConfirmationProps) => {
+  const onCancel = () => onClose();
+  const onConfirm = () => {
+    onConfirmation();
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalCloseButton />
+        <ModalBody pb="5" mt="5" textAlign="center">
+          <Text fontSize="4xl" my="5">
+            Are you sure?
+          </Text>
+          <Text color="gray.500">This action will update chapter</Text>
+          <Text fontSize="3xl">{chapter?.chapterName}</Text>
+          <Text color="gray.500">This action cannot be undone</Text>
+          <Divider my="5" />
+          <Flex>
+            <Button colorScheme="blue" onClick={onConfirm}>
+              Update
+            </Button>
+            <Spacer />
+            <Button onClick={onCancel}>Cancel</Button>
+          </Flex>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default EditConfirmationModal;

--- a/src/components/chapter-modals/ViewChapterModal.tsx
+++ b/src/components/chapter-modals/ViewChapterModal.tsx
@@ -115,8 +115,7 @@ const ViewChapterModal = () => {
   }, [activeChapter, chapters, upsertChapter]);
 
   const onEditClick = () => {
-    // TODO - Open Edit Modal for the active chapter
-    onClose();
+    setModalState(ModalState.EditChapter);
   };
 
   const onDeleteClick = () => {

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -14,12 +14,11 @@ import { Chapter, PrismaClient } from '@prisma/client';
 import { withAdminAuthPage } from '@/utils/middlewares/auth';
 import { SessionAdminUser } from '../api/admin/login';
 import { NextIronServerSideContext } from '@/utils/session';
-import ChapterModalController, {
-  ModalState,
-} from '@/components/chapter-modals/ChapterModalController';
+import ChapterModalController from '@/components/chapter-modals/ChapterModalController';
 import {
   ChapterModalContext,
   ChapterModalProvider,
+  ModalState,
 } from '@/providers/ChapterModalProvider';
 import ChapterCard from '@/components/ChapterCard';
 import {

--- a/src/pages/api/chapters/[chapterId].ts
+++ b/src/pages/api/chapters/[chapterId].ts
@@ -28,7 +28,7 @@ export type ChapterDetails = Chapter & {
 };
 
 export type ChapterResponse = {
-  chapter: Chapter | ChapterDetails;
+  chapter: Chapter | ChapterDetails | null;
 };
 
 async function handler(
@@ -69,6 +69,13 @@ async function handler(
           where: {
             id: parsedChapterId,
           },
+          include: {
+            chapterUser: {
+              include: {
+                user: true,
+              },
+            },
+          },
         });
 
         if (!chapterToUpdate) {
@@ -97,8 +104,13 @@ async function handler(
           });
         }
 
+        const { contactName, chapterName, email, phoneNumber } = updatedChapter;
+
         const data = {
-          ...updatedChapter,
+          contactName,
+          chapterName,
+          email,
+          phoneNumber,
         };
 
         await prisma.chapter.update({
@@ -108,9 +120,13 @@ async function handler(
           data,
         });
 
+        const returnChapter = {
+          ...chapterToUpdate,
+          ...data,
+        };
+
         return res.status(200).json({
-          message: 'Successfully updated the chapter',
-          error: false,
+          chapter: returnChapter as ChapterDetails,
         });
       } catch (e) {
         // console.error(e);

--- a/src/providers/ChapterModalProvider.tsx
+++ b/src/providers/ChapterModalProvider.tsx
@@ -16,7 +16,7 @@ export interface ChapterModalContextProps {
   currentModalState: ModalState;
   setModalState: (x: ModalState) => void;
   activeChapter: number;
-  setActiveChapter: (x: number) => void;
+  setActiveChapter: (id: number) => void;
 }
 
 export interface ChapterModalProviderProps {
@@ -33,11 +33,9 @@ export const ChapterModalContext = createContext<ChapterModalContextProps>({
   onOpen: () => {
     throw new Error('Method not implemented');
   },
-
   setModalState: (x: ModalState) => {
     throw new Error('Method not implemented');
   },
-
   setActiveChapter: (x: number) => {
     throw new Error('Method not implemented');
   },


### PR DESCRIPTION
### Description
This PR allows admins to update chapters information from the admin dashboard.
It uses `ChapterContext` to update cards when updated and make appropriate API calls to update the chapter in the database.

If no changes are made, the save button is disabled to prevent unnecessary updates.
![image](https://user-images.githubusercontent.com/43834826/140071969-0a194ff7-eece-4a23-9e7e-a57023898ef2.png)

To prevent accidentally updating a chapter, a confirmation modal will be displayed to the user before the chapter is updated.
![image](https://user-images.githubusercontent.com/43834826/140072225-346645dd-e6ff-4ba8-a502-231c1dcccb57.png)


**Related Issues/PRs:** 
- #47

### Test Plan

- Follow the test plans listed in #82
- Click on the chapter to update. It should open a modal with the chapter information.
- Click on the `Edit Chapter` button. It should open a form pre-populated with the existing information of the chapter.
- Make some changes to fields and undo them. The save button should be disabled since no changes were made.
- Make some changes to fields and click `Save`. It should open a confirmation modal.
  - Hit `Cancel`. It should return the user back to the edit form and the changes should not have been saved on the database.
  - Hit `Update`. It should show loading while the changes are being made in the database. After it completes, it should return the user back to the view modal with updated information.
