### PR TITLE
New recipient modal - Initialize Chapter Dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@chakra-ui/react": "1.6.7",
         "@emotion/react": "11.4.1",
         "@emotion/styled": "11.3.0",
-        "@prisma/client": "3.0.2",
+        "@prisma/client": "3.4.0",
         "@types/bcryptjs": "2.4.2",
         "@types/prop-types": "15.7.4",
         "bcryptjs": "2.4.3",
@@ -1936,12 +1936,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.0.2.tgz",
-      "integrity": "sha512-6SrDYY2Yr5AmYpVB3XAXFqfzxKMdDTemXR7FmfXthnxWhQHoBwRLNZ3B3GyI/MmWa5tr+kaaGDJjp1LU0vuYvQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.4.0.tgz",
+      "integrity": "sha512-rjnp7dPVArqT/VgeWllUN+5927u224Gud//d16omL2hyXl9BnWzmeZJQ0plTYuP5yCR/M1N4iUC8ysDPlhA08g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
+        "@prisma/engines-version": "3.4.0-27.1c9fdaa9e2319b814822d6dbfd0a69e1fcc13a85"
       },
       "engines": {
         "node": ">=12.6"
@@ -1963,9 +1963,9 @@
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db.tgz",
-      "integrity": "sha512-iArSApZZImVmT9oC/rGOjzvpG2AOqlIeqYcVnop9poA3FxD4zfVPbNPH9DTgOWhc06OkBHujJZeAcsNddVabIQ=="
+      "version": "3.4.0-27.1c9fdaa9e2319b814822d6dbfd0a69e1fcc13a85",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.4.0-27.1c9fdaa9e2319b814822d6dbfd0a69e1fcc13a85.tgz",
+      "integrity": "sha512-acL30wD3lj6qGAN9JIA+fhcd8j5I+Db9d1Pge2jwmK/QVbmbnH+lhTMV5pYIdgxbZWs9R+DoNnOHvUQCOW1xeQ=="
     },
     "node_modules/@reach/alert": {
       "version": "0.13.2",
@@ -11994,11 +11994,11 @@
       "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
     },
     "@prisma/client": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.0.2.tgz",
-      "integrity": "sha512-6SrDYY2Yr5AmYpVB3XAXFqfzxKMdDTemXR7FmfXthnxWhQHoBwRLNZ3B3GyI/MmWa5tr+kaaGDJjp1LU0vuYvQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.4.0.tgz",
+      "integrity": "sha512-rjnp7dPVArqT/VgeWllUN+5927u224Gud//d16omL2hyXl9BnWzmeZJQ0plTYuP5yCR/M1N4iUC8ysDPlhA08g==",
       "requires": {
-        "@prisma/engines-version": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
+        "@prisma/engines-version": "3.4.0-27.1c9fdaa9e2319b814822d6dbfd0a69e1fcc13a85"
       }
     },
     "@prisma/engines": {
@@ -12008,9 +12008,9 @@
       "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db.tgz",
-      "integrity": "sha512-iArSApZZImVmT9oC/rGOjzvpG2AOqlIeqYcVnop9poA3FxD4zfVPbNPH9DTgOWhc06OkBHujJZeAcsNddVabIQ=="
+      "version": "3.4.0-27.1c9fdaa9e2319b814822d6dbfd0a69e1fcc13a85",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.4.0-27.1c9fdaa9e2319b814822d6dbfd0a69e1fcc13a85.tgz",
+      "integrity": "sha512-acL30wD3lj6qGAN9JIA+fhcd8j5I+Db9d1Pge2jwmK/QVbmbnH+lhTMV5pYIdgxbZWs9R+DoNnOHvUQCOW1xeQ=="
     },
     "@reach/alert": {
       "version": "0.13.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@chakra-ui/react": "1.6.7",
     "@emotion/react": "11.4.1",
     "@emotion/styled": "11.3.0",
-    "@prisma/client": "3.0.2",
+    "@prisma/client": "3.4.0",
     "@types/bcryptjs": "2.4.2",
     "@types/prop-types": "15.7.4",
     "bcryptjs": "2.4.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,7 @@ model Recipient {
 model Chapter {
   id          Int          @id @default(autoincrement())
   chapterName String       @unique
+  chapterSlug String       @unique
   contactName String
   email       String
   phoneNumber String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,15 +39,20 @@ model RecipientUser {
 }
 
 model Recipient {
-  id             Int             @id @default(autoincrement())
-  name           String          @unique
-  email          String
-  phoneNumber    String
-  location       String
-  chapterId      Int
-  chapter        Chapter         @relation(fields: [chapterId], references: [id])
-  recipientUser  RecipientUser?
-  supplyRequests SupplyRequest[]
+  id                     Int             @id @default(autoincrement())
+  name                   String          @unique
+  email                  String
+  phoneNumber            String
+  chapterId              Int
+  chapter                Chapter         @relation(fields: [chapterId], references: [id])
+  recipientUser          RecipientUser?
+  supplyRequests         SupplyRequest[]
+  primaryStreetAddress   String
+  secondaryStreetAddress String?
+  city                   String
+  state                  String
+  country                String
+  postalCode             String
 }
 
 model Chapter {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -81,7 +81,11 @@ async function main() {
       name: 'Recipient Only',
       email: 'recipient_only@pfs.org',
       phoneNumber: '5555555555',
-      location: 'Atlanta',
+      primaryStreetAddress: '350 Ferst Drive',
+      city: 'Atlanta',
+      state: 'Georgia',
+      country: 'USA',
+      postalCode: '30332',
       chapter: {
         connect: {
           id: chapter.id,
@@ -105,7 +109,12 @@ async function main() {
               name: 'Recipient User',
               email: 'recipient_user@pfs.org',
               phoneNumber: '4444444444',
-              location: 'Savannah',
+              primaryStreetAddress: '1 Abercorn Street',
+              secondaryStreetAddress: 'Apt 420',
+              city: 'Savannah',
+              state: 'Georgia',
+              country: 'USA',
+              postalCode: '31419',
               chapter: {
                 connect: {
                   id: chapter.id,

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { generateChapterSlug } from '../src/utils/slug';
 import { getPasswordHash } from '../src/utils/password';
 
 const prisma = new PrismaClient();
@@ -44,6 +45,7 @@ async function main() {
     update: {},
     create: {
       chapterName: 'Texas',
+      chapterSlug: generateChapterSlug('Texas'),
       contactName: 'Texas Chapter User',
       email: 'texas@pfs.org',
       phoneNumber: '4048888888',
@@ -57,6 +59,7 @@ async function main() {
     update: {},
     create: {
       chapterName: 'Georgia',
+      chapterSlug: generateChapterSlug('Georgia'),
       email: 'georgia@pfs.org',
       contactName: 'Georgia Chapter User',
       phoneNumber: '4041110000',

--- a/src/components/RecipientCard.tsx
+++ b/src/components/RecipientCard.tsx
@@ -1,0 +1,26 @@
+import { Heading, Flex } from '@chakra-ui/react';
+import { Recipient } from '@prisma/client';
+
+interface RecipientCardProps {
+  recipient: Recipient;
+}
+
+function RecipientCard({ recipient }: RecipientCardProps) {
+  return (
+    <Flex
+      boxShadow="lg"
+      borderRadius="lg"
+      borderWidth="1px"
+      cursor="pointer"
+      direction="column"
+      alignItems="baseline"
+      padding="5"
+    >
+      <Heading size="md" paddingBottom="5">
+        {recipient.name}
+      </Heading>
+    </Flex>
+  );
+}
+
+export default RecipientCard;

--- a/src/pages/api/chapters/[chapterId].ts
+++ b/src/pages/api/chapters/[chapterId].ts
@@ -14,6 +14,7 @@ import { ErrorResponse, serverErrorHandler } from '@/utils/error';
 import { NextIronRequest } from '@/utils/session';
 import { withAuthedRequestSession } from '@/utils/middlewares/auth';
 import { validateChapterInput } from '@/utils/prisma-validation';
+import { generateChapterSlug } from '@/utils/slug';
 
 interface ChapterUpdateBody {
   updatedChapter: Prisma.ChapterCreateInput;
@@ -106,9 +107,12 @@ async function handler(
 
         const { contactName, chapterName, email, phoneNumber } = updatedChapter;
 
+        const chapterSlug = generateChapterSlug(chapterName);
+
         const data = {
           contactName,
           chapterName,
+          chapterSlug,
           email,
           phoneNumber,
         };

--- a/src/pages/api/chapters/index.ts
+++ b/src/pages/api/chapters/index.ts
@@ -9,6 +9,7 @@ import {
   validateNewUserInput,
 } from '@/utils/prisma-validation';
 import { ChapterDetails } from './[chapterId]';
+import { generateChapterSlug } from '@/utils/slug';
 
 export type GetChapterResponse = {
   chapters: Chapter[];
@@ -74,6 +75,8 @@ async function handler(
         } as Prisma.UserCreateInput;
 
         const passwordHash = await getPasswordHash(hash);
+
+        chapter.chapterSlug = generateChapterSlug(chapter.chapterName);
 
         // Add Prisma records
         const prisma = new PrismaClient();

--- a/src/pages/chapter/[chapterSlug].tsx
+++ b/src/pages/chapter/[chapterSlug].tsx
@@ -1,21 +1,9 @@
-import {
-  Box,
-  Button,
-  Flex,
-  Heading,
-  SimpleGrid,
-  Spacer,
-} from '@chakra-ui/react';
-import { PrismaClient, Chapter, Recipient } from '@prisma/client';
+import { Box, Flex, Heading, Spacer } from '@chakra-ui/react';
+import { PrismaClient, Chapter } from '@prisma/client';
 import React from 'react';
-import RecipientCard from '@/components/RecipientCard';
-
-type ChapterWithRecipients = Chapter & {
-  recipients: Recipient[];
-};
 
 interface ChapterMapPageProps {
-  chapter: ChapterWithRecipients;
+  chapter: Chapter;
 }
 
 interface IStaticPropsContextParams {
@@ -24,42 +12,13 @@ interface IStaticPropsContextParams {
   };
 }
 
-function AddNewRecipientButton() {
-  const onNewRecipientClick = () => {
-    alert('Open modal to create new recipient');
-  };
-
-  return (
-    <Button onClick={onNewRecipientClick} colorScheme="blue">
-      + Add New
-    </Button>
-  );
-}
-
-interface RecipientCardProps {
-  recipients: Recipient[];
-}
-
-function RecipientCardsGrid({ recipients }: RecipientCardProps) {
-  return (
-    <SimpleGrid columns={{ base: 1, md: 2, lg: 5 }} my="5" spacing="5">
-      {recipients.map((x) => (
-        <RecipientCard recipient={x} key={x.id} />
-      ))}
-    </SimpleGrid>
-  );
-}
-
-export default function ChapterMapPage({ chapter }: ChapterMapPageProps) {
+export default function ChapterDashboardPage({ chapter }: ChapterMapPageProps) {
   return (
     <Box p="10">
       <Flex>
-        <Heading>{chapter.chapterName} Chapter Recipients</Heading>
+        <Heading>{chapter.chapterName} Chapter </Heading>
         <Spacer />
-        <AddNewRecipientButton />
       </Flex>
-
-      <RecipientCardsGrid recipients={chapter.recipients || []} />
     </Box>
   );
 }
@@ -82,16 +41,12 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }: IStaticPropsContextParams) {
-  // TODO - Figure out how to allow case insensitive searches in Prisma
   const { chapterSlug } = params;
 
   const prisma = new PrismaClient();
   const chapter = await prisma.chapter.findUnique({
     where: {
       chapterSlug,
-    },
-    include: {
-      recipients: true,
     },
   });
 

--- a/src/pages/chapter/[chapterSlug].tsx
+++ b/src/pages/chapter/[chapterSlug].tsx
@@ -20,7 +20,7 @@ interface ChapterMapPageProps {
 
 interface IStaticPropsContextParams {
   params: {
-    chapterName: string;
+    chapterSlug: string;
   };
 }
 
@@ -68,14 +68,14 @@ export async function getStaticPaths() {
   const prisma = new PrismaClient();
   const rawChapters = await prisma.chapter.findMany({
     select: {
-      chapterName: true,
+      chapterSlug: true,
     },
   });
 
-  const chapters = rawChapters.map((x) => x.chapterName.trim().toLowerCase());
+  const chapters = rawChapters.map((x) => x.chapterSlug);
 
-  const paths = chapters.map((chapterName) => ({
-    params: { chapterName },
+  const paths = chapters.map((chapterSlug) => ({
+    params: { chapterSlug },
   }));
 
   return { paths, fallback: false };
@@ -83,12 +83,12 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }: IStaticPropsContextParams) {
   // TODO - Figure out how to allow case insensitive searches in Prisma
-  const { chapterName } = params;
+  const { chapterSlug } = params;
 
   const prisma = new PrismaClient();
   const chapter = await prisma.chapter.findUnique({
     where: {
-      chapterName: 'Georgia',
+      chapterSlug,
     },
     include: {
       recipients: true,

--- a/src/pages/chapter/index.tsx
+++ b/src/pages/chapter/index.tsx
@@ -1,0 +1,80 @@
+import React, { useContext } from 'react';
+import { GetServerSideProps } from 'next';
+import {
+  SimpleGrid,
+  Heading,
+  Text,
+  Button,
+  Box,
+  Flex,
+  Spacer,
+} from '@chakra-ui/react';
+import { Chapter, PrismaClient } from '@prisma/client';
+import { withChapterAuthPage } from '@/utils/middlewares/auth';
+import { SessionAdminUser } from '../api/admin/login';
+import { NextIronServerSideContext } from '@/utils/session';
+import ChapterCard from '@/components/ChapterCard';
+import { ChaptersContext } from '@/providers/ChaptersProvider';
+import { SessionChapterUser } from '../api/chapters/login';
+
+interface ChapterDashboardProps {
+  user: SessionAdminUser;
+  chapter: Chapter;
+  chapterError?: string;
+}
+
+function ChapterCardsGrid() {
+  const { chapters } = useContext(ChaptersContext);
+
+  return (
+    <SimpleGrid columns={{ base: 1, md: 2, lg: 5 }} my="5" spacing="5">
+      {Object.values(chapters).map((x) => (
+        <ChapterCard chapter={x} key={x.id} />
+      ))}
+    </SimpleGrid>
+  );
+}
+
+export default function AdminDashboardPage({
+  user,
+  chapter,
+  chapterError,
+}: ChapterDashboardProps) {
+  return (
+    <Box p="10">
+      <Flex>
+        <Heading>{chapter?.chapterName} Chapter</Heading>
+        <Spacer />
+        <Button colorScheme="blue">+ Add New</Button>
+      </Flex>
+
+      {chapterError && <Text>{chapterError}</Text>}
+    </Box>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<ChapterDashboardProps> =
+  withChapterAuthPage(async ({ req }: NextIronServerSideContext) => {
+    const user = req.session.get('user') as SessionChapterUser;
+
+    let chapter: Chapter | null;
+    let chapterError = '';
+    try {
+      const prisma = new PrismaClient();
+      chapter = await prisma.chapter.findUnique({
+        where: {
+          id: user.chapterUser.chapterId,
+        },
+      });
+      if (!chapter) {
+        chapterError = 'No chapter found';
+      }
+    } catch (e) {
+      chapter = null;
+      chapterError = 'Failed to retrieve the chapter. Please try again later';
+    }
+
+    return {
+      props: { user, chapter, chapterError },
+    };
+  });

--- a/src/pages/chapter/index.tsx
+++ b/src/pages/chapter/index.tsx
@@ -8,28 +8,35 @@ import {
   Box,
   Flex,
   Spacer,
+  Spinner,
 } from '@chakra-ui/react';
 import { Chapter, PrismaClient } from '@prisma/client';
 import { withChapterAuthPage } from '@/utils/middlewares/auth';
-import { SessionAdminUser } from '../api/admin/login';
 import { NextIronServerSideContext } from '@/utils/session';
-import ChapterCard from '@/components/ChapterCard';
-import { ChaptersContext } from '@/providers/ChaptersProvider';
 import { SessionChapterUser } from '../api/chapters/login';
+import {
+  RecipientsContext,
+  RecipientsProvider,
+} from '@/providers/RecipientsProvider';
+import RecipientCard from '@/components/RecipientCard';
 
 interface ChapterDashboardProps {
-  user: SessionAdminUser;
+  user: SessionChapterUser;
   chapter: Chapter;
   chapterError?: string;
 }
 
-function ChapterCardsGrid() {
-  const { chapters } = useContext(ChaptersContext);
+function RecipientsCardsGrid() {
+  const { recipients, loading } = useContext(RecipientsContext);
+
+  if (loading) {
+    return <Spinner />;
+  }
 
   return (
     <SimpleGrid columns={{ base: 1, md: 2, lg: 5 }} my="5" spacing="5">
-      {Object.values(chapters).map((x) => (
-        <ChapterCard chapter={x} key={x.id} />
+      {recipients.map((x) => (
+        <RecipientCard recipient={x} key={x.id} />
       ))}
     </SimpleGrid>
   );
@@ -40,16 +47,22 @@ export default function AdminDashboardPage({
   chapter,
   chapterError,
 }: ChapterDashboardProps) {
-  return (
-    <Box p="10">
-      <Flex>
-        <Heading>{chapter?.chapterName} Chapter</Heading>
-        <Spacer />
-        <Button colorScheme="blue">+ Add New</Button>
-      </Flex>
+  const { chapterId } = user.chapterUser;
 
-      {chapterError && <Text>{chapterError}</Text>}
-    </Box>
+  return (
+    <RecipientsProvider chapterId={chapterId}>
+      <Box p="10">
+        <Flex>
+          <Heading>{chapter?.chapterName} Chapter</Heading>
+          <Spacer />
+          <Button colorScheme="blue">+ Add New</Button>
+        </Flex>
+
+        {chapterError && <Text>{chapterError}</Text>}
+
+        <RecipientsCardsGrid />
+      </Box>
+    </RecipientsProvider>
   );
 }
 

--- a/src/pages/chapter/index.tsx
+++ b/src/pages/chapter/index.tsx
@@ -27,10 +27,14 @@ interface ChapterDashboardProps {
 }
 
 function RecipientsCardsGrid() {
-  const { recipients, loading } = useContext(RecipientsContext);
+  const { recipients, loading, error } = useContext(RecipientsContext);
 
   if (loading) {
     return <Spinner />;
+  }
+
+  if (error) {
+    return <Text>{error}</Text>;
   }
 
   return (
@@ -42,7 +46,21 @@ function RecipientsCardsGrid() {
   );
 }
 
-export default function AdminDashboardPage({
+function AddNewRecipientButton() {
+  //   const { onOpen, setModalState } = useContext(ChapterModalContext);
+
+  const onNewChapterClick = () => {
+    alert('Creating new recipient');
+  };
+
+  return (
+    <Button onClick={onNewChapterClick} colorScheme="blue">
+      + Add New
+    </Button>
+  );
+}
+
+export default function ChapterDashboardPage({
   user,
   chapter,
   chapterError,
@@ -55,7 +73,7 @@ export default function AdminDashboardPage({
         <Flex>
           <Heading>{chapter?.chapterName} Chapter</Heading>
           <Spacer />
-          <Button colorScheme="blue">+ Add New</Button>
+          <AddNewRecipientButton />
         </Flex>
 
         {chapterError && <Text>{chapterError}</Text>}

--- a/src/providers/RecipientsProvider.tsx
+++ b/src/providers/RecipientsProvider.tsx
@@ -3,6 +3,7 @@ import { Recipient } from '@prisma/client';
 
 export interface RecipientsContextProps {
   recipients: Recipient[];
+  chapterId: number;
   loading: boolean;
   error?: string;
   upsertRecipient: (data: Recipient) => void;
@@ -16,6 +17,7 @@ export interface ChaptersProviderProps {
 
 export const RecipientsContext = createContext<RecipientsContextProps>({
   recipients: [],
+  chapterId: -1,
   loading: true,
   removeRecipient: (id: number) => {
     throw Error('Method not implemented');
@@ -26,7 +28,7 @@ export const RecipientsContext = createContext<RecipientsContextProps>({
 });
 
 const getRecipients = async (chapterId: number) => {
-  if (!chapterId) {
+  if (!chapterId || chapterId < 0) {
     throw Error('Please provide a valid chapter id');
   }
 
@@ -82,6 +84,7 @@ export const RecipientsProvider = ({
   return (
     <RecipientsContext.Provider
       value={{
+        chapterId,
         recipients,
         loading,
         error,

--- a/src/providers/RecipientsProvider.tsx
+++ b/src/providers/RecipientsProvider.tsx
@@ -1,0 +1,95 @@
+import { createContext, useEffect, useState } from 'react';
+import { Recipient } from '@prisma/client';
+
+export interface RecipientsContextProps {
+  recipients: Recipient[];
+  loading: boolean;
+  error?: string;
+  upsertRecipient: (data: Recipient) => void;
+  removeRecipient: (id: number) => void;
+}
+
+export interface ChaptersProviderProps {
+  children: JSX.Element;
+  chapterId: number;
+}
+
+export const RecipientsContext = createContext<RecipientsContextProps>({
+  recipients: [],
+  loading: true,
+  removeRecipient: (id: number) => {
+    throw Error('Method not implemented');
+  },
+  upsertRecipient: (x: Recipient) => {
+    throw Error('Method not implemented');
+  },
+});
+
+const getRecipients = async (chapterId: number) => {
+  if (!chapterId) {
+    throw Error('Please provide a valid chapter id');
+  }
+
+  const response = await fetch(`/api/chapters/${chapterId}/recipients`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const responseJson = await response.json();
+  if (response.status !== 200 || responseJson.error) {
+    throw Error(responseJson.message);
+  }
+
+  return responseJson.recipients as Recipient[];
+};
+
+export const RecipientsProvider = ({
+  children,
+  chapterId,
+}: ChaptersProviderProps) => {
+  const [recipients, setRecipients] = useState<Recipient[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    setLoading(true);
+    getRecipients(chapterId)
+      .then((data) => setRecipients(data))
+      .catch((err) => setError(err))
+      .finally(() => setLoading(false));
+  }, [chapterId]);
+
+  const removeRecipient = (id: number) => {
+    const filteredRecipients = recipients.filter((x) => x.id !== id);
+    setRecipients(filteredRecipients);
+  };
+
+  const upsertRecipient = (data: Recipient) => {
+    // Check if existing recipient
+    const recipientIndex = recipients.findIndex((x) => x.id === data.id);
+    const newRecipients = [...recipients];
+    if (recipientIndex >= 0) {
+      newRecipients[recipientIndex] = data;
+    } else {
+      newRecipients.push(data);
+    }
+
+    setRecipients(recipients);
+  };
+
+  return (
+    <RecipientsContext.Provider
+      value={{
+        recipients,
+        loading,
+        error,
+        removeRecipient,
+        upsertRecipient,
+      }}
+    >
+      {children}
+    </RecipientsContext.Provider>
+  );
+};

--- a/src/utils/middlewares/auth.ts
+++ b/src/utils/middlewares/auth.ts
@@ -1,5 +1,6 @@
 import { NextApiResponse } from 'next';
 import { Handler } from 'next-iron-session';
+import { SessionChapterUser } from '@/pages/api/chapters/login';
 import { SessionAdminUser } from '@/pages/api/admin/login';
 import {
   NextIronContextHandler,
@@ -52,6 +53,25 @@ export function withAdminAuthPage(handler: NextIronContextHandler) {
 
     if (!user || !user.isLoggedIn || !user.admin) {
       res.setHeader('location', '/admin/login');
+      res.statusCode = 302;
+      res.end();
+      // Even if redirecting to a different location, getServerSideProps expects valid return
+      return {
+        props: {},
+      };
+    }
+
+    return handler(ctx, null);
+  });
+}
+
+export function withChapterAuthPage(handler: NextIronContextHandler) {
+  return withSession((ctx: NextIronServerSideContext) => {
+    const { req, res } = ctx;
+    const user = req.session.get('user') as SessionChapterUser;
+
+    if (!user || !user.isLoggedIn || !user.chapterUser) {
+      res.setHeader('location', '/chapter/login');
       res.statusCode = 302;
       res.end();
       // Even if redirecting to a different location, getServerSideProps expects valid return

--- a/src/utils/prisma-validation.ts
+++ b/src/utils/prisma-validation.ts
@@ -26,7 +26,7 @@ export function validateUsername(username: string | undefined) {
     throw Error('Please provide a username of valid length');
   }
 
-  if (username.match(/^[a-zA-Z0-9_]*$/)) {
+  if (!username.match(/^[a-zA-Z0-9_]*$/)) {
     throw Error('Please provide an alphanumeric username');
   }
 }

--- a/src/utils/prisma-validation.ts
+++ b/src/utils/prisma-validation.ts
@@ -76,14 +76,39 @@ export function validateRecipientInput(
   recipient: Prisma.RecipientCreateInput | undefined,
 ) {
   if (recipient) {
-    const { name, email, phoneNumber, location } = recipient;
+    const {
+      name,
+      email,
+      phoneNumber,
+      primaryStreetAddress,
+      city,
+      state,
+      country,
+      postalCode,
+    } = recipient;
 
     if (!isNonEmpty(name)) {
       throw Error('Please provide a valid recipient name');
     }
 
-    if (!isNonEmpty(location)) {
-      throw Error('Please provide a valid location');
+    if (!isNonEmpty(primaryStreetAddress)) {
+      throw Error('Please provide a valid street address');
+    }
+
+    if (!isNonEmpty(city)) {
+      throw Error('Please provide a valid city');
+    }
+
+    if (!isNonEmpty(state)) {
+      throw Error('Please provide a valid state');
+    }
+
+    if (!isNonEmpty(country)) {
+      throw Error('Please provide a valid country');
+    }
+
+    if (!isNonEmpty(postalCode)) {
+      throw Error('Please provide a valid postal code');
     }
 
     validateEmail(email);

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,0 +1,11 @@
+export function generateChapterSlug(chapterName: string) {
+  let slug = chapterName.trim().toLowerCase();
+  slug = slug
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(/[^\w-\d]+/g, '') // Remove all non-word and no-digit chars
+    .replace(/--+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, ''); // Trim - from end of text
+
+  return slug;
+}


### PR DESCRIPTION
### Description
Create a chapter dashboard to view details about a chapter. When an authorized chapter user logs in and visits the`/chapter` page, it should display the chapter name for the user and list all of its recipients.

The location field has also been split into individual fields.

Slugs are generated dynamically when new chapters are created or updated. These slugs can then be used to visit the dashboard - `/chapter/:chapterSlug`.

**Related Issues/PRs:** 
- #73

### Test Plan
**Authorized user**
- Login as a chapter user.
- Visit `/chapter` page. It should display a dashboard of the chapter for which the chapter user owns. It should list all the recipients for that chapter.

**Unauthorized user**
- Logout as a chapter user.
- Visit `/chapter` page. It should redirect you to the chapter user login page.

