### PR TITLE
Create new recipient modal

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,7 @@ model RecipientUser {
 model Recipient {
   id                     Int             @id @default(autoincrement())
   name                   String          @unique
+  contactName            String
   email                  String
   phoneNumber            String
   chapterId              Int

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -82,6 +82,7 @@ async function main() {
     update: {},
     create: {
       name: 'Recipient Only',
+      contactName: 'George Burdell',
       email: 'recipient_only@pfs.org',
       phoneNumber: '5555555555',
       primaryStreetAddress: '350 Ferst Drive',
@@ -111,6 +112,7 @@ async function main() {
             create: {
               name: 'Recipient User',
               email: 'recipient_user@pfs.org',
+              contactName: 'General Oglethorpe',
               phoneNumber: '4444444444',
               primaryStreetAddress: '1 Abercorn Street',
               secondaryStreetAddress: 'Apt 420',

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -121,23 +121,6 @@ async function main() {
       recipient: {
         create: {
           recipient: {
-            create: {
-              name: 'Recipient User',
-              email: 'recipient_user@pfs.org',
-              contactName: 'General Oglethorpe',
-              phoneNumber: '4444444444',
-              primaryStreetAddress: '1 Abercorn Street',
-              secondaryStreetAddress: 'Apt 420',
-              city: 'Savannah',
-              state: 'Georgia',
-              country: 'USA',
-              postalCode: '31419',
-              chapter: {
-                connect: {
-                  id: chapter.id,
-                },
-              },
-            },
             connect: {
               id: recipient.id,
             },

--- a/src/components/recipient-modals/NewRecipientModal.tsx
+++ b/src/components/recipient-modals/NewRecipientModal.tsx
@@ -23,6 +23,7 @@ type NewRecipientFormBody = {
   name: string;
   username: string;
   password: string;
+  contactName: string;
   email: string;
   phoneNumber?: number;
   primaryStreetAddress: string;
@@ -51,10 +52,12 @@ const createNewRecipient = async (data: NewRecipientFormBody) => {
     postalCode,
     username,
     password,
+    contactName,
   } = data;
 
   const recipient = {
     name,
+    contactName,
     email,
     phoneNumber,
     primaryStreetAddress,
@@ -186,6 +189,25 @@ const NewRecipientModal = ({ isOpen, onClose }: NewRecipientModalProps) => {
 
             <FormControl isRequired>
               <FormLabel>Contact Info</FormLabel>
+            </FormControl>
+
+            <FormControl
+              isRequired
+              isInvalid={errors.contactName !== undefined}
+              mb={2}
+              id="contactName"
+            >
+              <Input
+                placeholder="Contact Name"
+                type="contactName"
+                {...register('contactName', {
+                  required: 'Email is required',
+                })}
+                borderColor="black"
+              />
+              <FormErrorMessage>
+                {errors.contactName && errors.contactName.message}
+              </FormErrorMessage>
             </FormControl>
 
             <SimpleGrid columns={[1, null, 2]} spacing={[0, null, 5]}>

--- a/src/components/recipient-modals/NewRecipientModal.tsx
+++ b/src/components/recipient-modals/NewRecipientModal.tsx
@@ -280,7 +280,7 @@ const NewRecipientModal = ({ isOpen, onClose }: NewRecipientModalProps) => {
               id="secondaryStreetAddress"
             >
               <Input
-                placeholder="Apt, Suite, etc."
+                placeholder="Apt, Suite, etc. (Optional)"
                 {...register('secondaryStreetAddress')}
                 borderColor="black"
               />

--- a/src/components/recipient-modals/NewRecipientModal.tsx
+++ b/src/components/recipient-modals/NewRecipientModal.tsx
@@ -1,0 +1,359 @@
+import React, { useContext } from 'react';
+import {
+  Button,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  SimpleGrid,
+} from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { emailRegex } from '@/utils/prisma-validation';
+import { ErrorResponse } from '@/utils/error';
+import { RecipientsContext } from '@/providers/RecipientsProvider';
+import { PostRecipientResponse } from '@/pages/api/recipients';
+
+type NewRecipientFormBody = {
+  name: string;
+  username: string;
+  password: string;
+  email: string;
+  phoneNumber?: number;
+  primaryStreetAddress: string;
+  secondaryStreetAddress?: string;
+  city: string;
+  state: string;
+  country: string;
+  postalCode: string;
+};
+
+interface NewRecipientModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const createNewRecipient = async (data: NewRecipientFormBody) => {
+  const {
+    name,
+    email,
+    phoneNumber,
+    primaryStreetAddress,
+    secondaryStreetAddress,
+    city,
+    state,
+    country,
+    postalCode,
+    username,
+    password,
+  } = data;
+
+  const recipient = {
+    name,
+    email,
+    phoneNumber,
+    primaryStreetAddress,
+    secondaryStreetAddress,
+    city,
+    state,
+    country,
+    postalCode,
+  };
+
+  const newUser = {
+    username,
+    hash: password,
+  };
+
+  const response = await fetch(`/api/recipients`, {
+    method: 'POST',
+    body: JSON.stringify({
+      recipient,
+      newUser,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const responseJson = (await response.json()) as PostRecipientResponse &
+    ErrorResponse;
+  if (response.status !== 200 || responseJson.error) {
+    throw Error(responseJson.message);
+  }
+
+  return responseJson.recipient;
+};
+
+const NewRecipientModal = ({ isOpen, onClose }: NewRecipientModalProps) => {
+  const {
+    handleSubmit,
+    register,
+    formState: { errors, isSubmitting },
+  } = useForm<NewRecipientFormBody>({});
+
+  const { upsertRecipient } = useContext(RecipientsContext);
+
+  const onSubmit = async (data: NewRecipientFormBody) => {
+    try {
+      const newRecipient = await createNewRecipient(data);
+      upsertRecipient(newRecipient);
+      onClose();
+      alert(`Successfully added new recipient: ${newRecipient.id}`);
+    } catch (e) {
+      alert(e);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered size="xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Create New Recipient</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb="5">
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <FormControl
+              isRequired
+              isInvalid={errors.name !== undefined}
+              mt={2}
+              mb={2}
+              id="chapterName"
+            >
+              <FormLabel htmlFor="chapterName">
+                Recipient Organization Name
+              </FormLabel>
+              <Input
+                placeholder="Enter Name"
+                {...register('name', {
+                  required: 'Recipient Organization Name is required',
+                })}
+                borderColor="black"
+              />
+              <FormErrorMessage>
+                {errors.name && errors.name.message}
+              </FormErrorMessage>
+            </FormControl>
+            <FormControl isRequired>
+              <FormLabel>Credentials</FormLabel>
+            </FormControl>
+            <FormControl
+              isRequired
+              isInvalid={errors.username !== undefined}
+              mt={2}
+              mb={2}
+              id="username"
+            >
+              <Input
+                placeholder="Username"
+                {...register('username', {
+                  required: 'Username is required',
+                })}
+                borderColor="black"
+              />
+              <FormErrorMessage>
+                {errors.username && errors.username.message}
+              </FormErrorMessage>
+            </FormControl>
+
+            <FormControl
+              isRequired
+              isInvalid={errors.password !== undefined}
+              mb={2}
+              id="password"
+            >
+              <Input
+                placeholder="Password"
+                type="password"
+                {...register('password', {
+                  required: 'Password is required',
+                  minLength: {
+                    value: 8,
+                    message: 'Minimum length should be 8',
+                  },
+                })}
+                borderColor="black"
+              />
+              <FormErrorMessage>
+                {errors.password && errors.password.message}
+              </FormErrorMessage>
+            </FormControl>
+
+            <FormControl isRequired>
+              <FormLabel>Contact Info</FormLabel>
+            </FormControl>
+
+            <SimpleGrid columns={[1, null, 2]} spacing={[0, null, 5]}>
+              <FormControl
+                isRequired
+                isInvalid={errors.email !== undefined}
+                mb={2}
+                id="email"
+              >
+                <Input
+                  placeholder="Email"
+                  type="email"
+                  {...register('email', {
+                    required: 'Email is required',
+                    pattern: {
+                      value: emailRegex,
+                      message: 'Invalid email address',
+                    },
+                  })}
+                  borderColor="black"
+                />
+                <FormErrorMessage>
+                  {errors.email && errors.email.message}
+                </FormErrorMessage>
+              </FormControl>
+
+              <FormControl
+                isInvalid={errors.phoneNumber !== undefined}
+                mb={2}
+                id="phoneNumber"
+              >
+                <Input
+                  placeholder="Phone Number (Optional)"
+                  type="number"
+                  {...register('phoneNumber')}
+                  borderColor="black"
+                />
+                <FormErrorMessage>
+                  {errors.phoneNumber && errors.phoneNumber.message}
+                </FormErrorMessage>
+              </FormControl>
+            </SimpleGrid>
+
+            <FormControl isRequired>
+              <FormLabel>Address</FormLabel>
+            </FormControl>
+
+            <FormControl
+              isRequired
+              isInvalid={errors.primaryStreetAddress !== undefined}
+              mb={2}
+              id="primaryStreetAddress"
+            >
+              <Input
+                placeholder="Street Address"
+                {...register('primaryStreetAddress', {
+                  required: 'Street address is required',
+                })}
+                borderColor="black"
+              />
+              <FormErrorMessage>
+                {errors.primaryStreetAddress &&
+                  errors.primaryStreetAddress.message}
+              </FormErrorMessage>
+            </FormControl>
+
+            <FormControl
+              isInvalid={errors.secondaryStreetAddress !== undefined}
+              mb={2}
+              id="secondaryStreetAddress"
+            >
+              <Input
+                placeholder="Apt, Suite, etc."
+                {...register('secondaryStreetAddress')}
+                borderColor="black"
+              />
+              <FormErrorMessage>
+                {errors.secondaryStreetAddress &&
+                  errors.secondaryStreetAddress.message}
+              </FormErrorMessage>
+            </FormControl>
+
+            <SimpleGrid columns={[1, null, 2]} spacing={[0, null, 2]}>
+              <FormControl
+                isRequired
+                isInvalid={errors.city !== undefined}
+                id="city"
+              >
+                <Input
+                  placeholder="City"
+                  {...register('city', {
+                    required: 'City is required',
+                  })}
+                  borderColor="black"
+                />
+                <FormErrorMessage>
+                  {errors.city && errors.city.message}
+                </FormErrorMessage>
+              </FormControl>
+
+              <FormControl isInvalid={errors.state !== undefined} id="state">
+                <Input
+                  placeholder="State"
+                  {...register('state', {
+                    required: 'State is required',
+                  })}
+                  borderColor="black"
+                />
+                <FormErrorMessage>
+                  {errors.state && errors.state.message}
+                </FormErrorMessage>
+              </FormControl>
+
+              <FormControl
+                isInvalid={errors.country !== undefined}
+                id="country"
+              >
+                <Input
+                  placeholder="Country"
+                  {...register('country', {
+                    required: 'Country is required',
+                  })}
+                  borderColor="black"
+                />
+                <FormErrorMessage>
+                  {errors.country && errors.country.message}
+                </FormErrorMessage>
+              </FormControl>
+
+              <FormControl
+                isInvalid={errors.postalCode !== undefined}
+                id="postalCode"
+              >
+                <Input
+                  placeholder="Postal Code"
+                  {...register('postalCode', {
+                    required: 'Postal Code is required',
+                  })}
+                  borderColor="black"
+                />
+                <FormErrorMessage>
+                  {errors.postalCode && errors.postalCode.message}
+                </FormErrorMessage>
+              </FormControl>
+            </SimpleGrid>
+
+            <SimpleGrid columns={[1, null, 2]} spacing={[0, null, 5]} mt="4">
+              <Button
+                isLoading={isSubmitting}
+                type="submit"
+                colorScheme="messenger"
+              >
+                Submit
+              </Button>
+              <Button
+                isLoading={isSubmitting}
+                onClick={onClose}
+                disabled={isSubmitting}
+                variant="ghost"
+              >
+                Cancel
+              </Button>
+            </SimpleGrid>
+          </form>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default NewRecipientModal;

--- a/src/pages/api/recipients/index.ts
+++ b/src/pages/api/recipients/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiResponse } from 'next';
-import { PrismaClient, Prisma } from '@prisma/client';
+import { PrismaClient, Prisma, Recipient } from '@prisma/client';
 import { ErrorResponse, serverErrorHandler } from '@/utils/error';
 import { NextIronRequest, withSession } from '@/utils/session';
 import { getPasswordHash } from '@/utils/password';
@@ -14,9 +14,13 @@ export type NewRecipientInputBody = {
   newUser: Prisma.RecipientUserCreateInput & Prisma.UserCreateInput;
 };
 
+export type PostRecipientResponse = {
+  recipient: Recipient;
+};
+
 async function handler(
   req: NextIronRequest,
-  res: NextApiResponse<ErrorResponse>,
+  res: NextApiResponse<ErrorResponse | PostRecipientResponse>,
 ) {
   switch (req.method) {
     case 'POST':
@@ -85,8 +89,7 @@ async function handler(
         });
 
         return res.status(200).json({
-          error: false,
-          message: `Successfully created a recipient: ${createdRecipient.id}`,
+          recipient: createdRecipient,
         });
       } catch (e) {
         return serverErrorHandler(e, res);

--- a/src/pages/chapter/index.tsx
+++ b/src/pages/chapter/index.tsx
@@ -9,6 +9,7 @@ import {
   Flex,
   Spacer,
   Spinner,
+  useDisclosure,
 } from '@chakra-ui/react';
 import { Chapter, PrismaClient } from '@prisma/client';
 import { withChapterAuthPage } from '@/utils/middlewares/auth';
@@ -19,6 +20,7 @@ import {
   RecipientsProvider,
 } from '@/providers/RecipientsProvider';
 import RecipientCard from '@/components/RecipientCard';
+import NewRecipientModal from '@/components/recipient-modals/NewRecipientModal';
 
 interface ChapterDashboardProps {
   user: SessionChapterUser;
@@ -46,20 +48,6 @@ function RecipientsCardsGrid() {
   );
 }
 
-function AddNewRecipientButton() {
-  //   const { onOpen, setModalState } = useContext(ChapterModalContext);
-
-  const onNewChapterClick = () => {
-    alert('Creating new recipient');
-  };
-
-  return (
-    <Button onClick={onNewChapterClick} colorScheme="blue">
-      + Add New
-    </Button>
-  );
-}
-
 export default function ChapterDashboardPage({
   user,
   chapter,
@@ -67,18 +55,23 @@ export default function ChapterDashboardPage({
 }: ChapterDashboardProps) {
   const { chapterId } = user.chapterUser;
 
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
   return (
     <RecipientsProvider chapterId={chapterId}>
       <Box p="10">
         <Flex>
           <Heading>{chapter?.chapterName} Chapter</Heading>
           <Spacer />
-          <AddNewRecipientButton />
+          <Button onClick={onOpen} colorScheme="blue">
+            + Add New
+          </Button>
         </Flex>
 
         {chapterError && <Text>{chapterError}</Text>}
 
         <RecipientsCardsGrid />
+        <NewRecipientModal isOpen={isOpen} onClose={onClose} />
       </Box>
     </RecipientsProvider>
   );

--- a/src/providers/RecipientsProvider.tsx
+++ b/src/providers/RecipientsProvider.tsx
@@ -78,7 +78,7 @@ export const RecipientsProvider = ({
       newRecipients.push(data);
     }
 
-    setRecipients(recipients);
+    setRecipients(newRecipients);
   };
 
   return (

--- a/src/utils/prisma-validation.ts
+++ b/src/utils/prisma-validation.ts
@@ -79,6 +79,7 @@ export function validateRecipientInput(
   if (recipient) {
     const {
       name,
+      contactName,
       email,
       phoneNumber,
       primaryStreetAddress,
@@ -90,6 +91,10 @@ export function validateRecipientInput(
 
     if (!isNonEmpty(name)) {
       throw Error('Please provide a valid recipient name');
+    }
+
+    if (!isNonEmpty(contactName)) {
+      throw Error('Please provide a valid contact name');
     }
 
     if (!isNonEmpty(primaryStreetAddress)) {


### PR DESCRIPTION
### Description
This PR adds a modal that allows chapter users to add new recipients for their chapter. Note, the logged in user must be a chapter user and they can only create recipients for their assigned chapters.

**Related Issues/PRs:** 

- Closes #73

### Test Plan
- Login as a chapter user and visit `/chapter`.
- Click on `+Add New` button. This should open a modal to add new recipient.
![image](https://user-images.githubusercontent.com/43834826/140623066-7d5f9f9c-ecaf-491b-8158-1948c6b6e296.png)

- Submit form without adding any data. It should show missing field errors and nothing is added to the database.
- Fill out the form with valid data and click submit. It should add the new recipient to the database and show it in the dashboard.
