### PR TITLE
Add form to update chapter user credentials

### DIFF
--- a/src/components/chapter-modals/EditChapterForm.tsx
+++ b/src/components/chapter-modals/EditChapterForm.tsx
@@ -1,0 +1,218 @@
+import { Chapter } from '@prisma/client';
+import React, { useContext, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import {
+  Button,
+  Divider,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  SimpleGrid,
+  Spacer,
+  useDisclosure,
+} from '@chakra-ui/react';
+import {
+  ChapterModalContext,
+  ModalState,
+} from '@/providers/ChapterModalProvider';
+import { emailRegex, validateChapterInput } from '@/utils/prisma-validation';
+import { ChapterDetails } from '@/pages/api/chapters/[chapterId]';
+import { ChaptersContext } from '@/providers/ChaptersProvider';
+import EditConfirmationModal from './EditConfirmationModal';
+
+interface ChapterInformationFormProps {
+  chapterToEdit: Chapter;
+}
+
+const editChapter = async (id: number, updatedChapter: Chapter) => {
+  validateChapterInput(updatedChapter);
+
+  const response = await fetch(`/api/chapters/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ updatedChapter }),
+  });
+
+  const responseJson = await response.json();
+  if (response.status !== 200) {
+    throw Error(responseJson.message);
+  }
+
+  if (responseJson.error) {
+    throw Error(responseJson.message);
+  }
+
+  return responseJson.chapter as ChapterDetails;
+};
+
+const ChapterInformationForm = ({
+  chapterToEdit,
+}: ChapterInformationFormProps) => {
+  const { activeChapter, setModalState } = useContext(ChapterModalContext);
+  const { upsertChapter } = useContext(ChaptersContext);
+
+  const [editedChapter, setEditedChapter] = useState<Chapter>(chapterToEdit);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setEditedChapter(chapterToEdit);
+  }, [chapterToEdit]);
+
+  const {
+    handleSubmit,
+    register,
+    formState: { errors, isSubmitting, isDirty },
+  } = useForm<Chapter>({
+    defaultValues: {
+      ...chapterToEdit,
+    },
+  });
+
+  // Manage edit confirmation modal
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const onCancel = () => {
+    setModalState(ModalState.ViewChapter);
+  };
+
+  const onSubmit = async (data: Chapter) => {
+    // If valid inputs, open confirmfation modal
+    setEditedChapter(data);
+    onOpen();
+  };
+
+  const onConfirmation = async () => {
+    setLoading(true);
+    editChapter(activeChapter, editedChapter)
+      .then((newChapter) => {
+        upsertChapter(newChapter);
+        setModalState(ModalState.ViewChapter);
+      })
+      .catch((err) => {
+        alert(err);
+      })
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <>
+      <EditConfirmationModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onConfirmation={onConfirmation}
+        chapter={chapterToEdit}
+      />
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <FormControl
+          isRequired
+          isInvalid={errors.chapterName !== undefined}
+          mt={2}
+          mb={2}
+          id="chapterName"
+        >
+          <FormLabel htmlFor="chapterName">Chapter Name</FormLabel>
+          <Input
+            placeholder="Enter Name"
+            {...register('chapterName', {
+              required: 'Chapter Name is required',
+            })}
+            borderColor="black"
+          />
+          <FormErrorMessage>
+            {errors.chapterName && errors.chapterName.message}
+          </FormErrorMessage>
+        </FormControl>
+
+        <FormControl isRequired>
+          <FormLabel>Contact Info</FormLabel>
+        </FormControl>
+        <FormControl
+          isRequired
+          isInvalid={errors.contactName !== undefined}
+          mt={2}
+          mb={2}
+          id="contactName"
+        >
+          <Input
+            placeholder="Contact Name"
+            {...register('contactName', {
+              required: 'Contact name is required',
+            })}
+            borderColor="black"
+          />
+          <FormErrorMessage>
+            {errors.contactName && errors.contactName.message}
+          </FormErrorMessage>
+        </FormControl>
+
+        <SimpleGrid columns={[1, null, 2]} spacing={[0, null, 5]}>
+          <FormControl
+            isRequired
+            isInvalid={errors.email !== undefined}
+            mb={2}
+            id="email"
+          >
+            <Input
+              placeholder="Email"
+              type="email"
+              {...register('email', {
+                required: 'Email is required',
+                pattern: {
+                  value: emailRegex,
+                  message: 'Invalid email address',
+                },
+              })}
+              borderColor="black"
+            />
+            <FormErrorMessage>
+              {errors.email && errors.email.message}
+            </FormErrorMessage>
+          </FormControl>
+
+          <FormControl
+            isInvalid={errors.phoneNumber !== undefined}
+            mb={2}
+            id="phoneNumber"
+          >
+            <Input
+              placeholder="Phone Number (Optional)"
+              type="number"
+              {...register('phoneNumber')}
+              borderColor="black"
+            />
+            <FormErrorMessage>
+              {errors.phoneNumber && errors.phoneNumber.message}
+            </FormErrorMessage>
+          </FormControl>
+        </SimpleGrid>
+
+        <Flex my="2">
+          <Button
+            colorScheme="blue"
+            isLoading={isSubmitting || loading}
+            disabled={!isDirty}
+            type="submit"
+          >
+            Save
+          </Button>
+
+          <Spacer />
+
+          <Button
+            disabled={isSubmitting || loading}
+            onClick={onCancel}
+            variant="ghost"
+          >
+            Cancel
+          </Button>
+        </Flex>
+      </form>
+    </>
+  );
+};
+
+export default ChapterInformationForm;

--- a/src/components/chapter-modals/EditChapterForm.tsx
+++ b/src/components/chapter-modals/EditChapterForm.tsx
@@ -105,6 +105,7 @@ const ChapterInformationForm = ({
         onClose={onClose}
         onConfirmation={onConfirmation}
         chapter={chapterToEdit}
+        message="This action will update chapter"
       />
       <form onSubmit={handleSubmit(onSubmit)}>
         <FormControl

--- a/src/components/chapter-modals/EditChapterModal.tsx
+++ b/src/components/chapter-modals/EditChapterModal.tsx
@@ -1,219 +1,26 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import {
   ModalBody,
   ModalCloseButton,
   ModalContent,
-  Button,
-  Flex,
-  Spacer,
-  Divider,
   ModalHeader,
-  FormControl,
-  FormLabel,
-  Input,
-  FormErrorMessage,
-  SimpleGrid,
-  useDisclosure,
 } from '@chakra-ui/react';
-import { useForm } from 'react-hook-form';
-import { Chapter } from '@prisma/client';
-import {
-  ChapterModalContext,
-  ModalState,
-} from '@/providers/ChapterModalProvider';
+import { ChapterModalContext } from '@/providers/ChapterModalProvider';
 import { ChaptersContext } from '@/providers/ChaptersProvider';
-import { emailRegex, validateChapterInput } from '@/utils/prisma-validation';
-import EditConfirmationModal from './EditConfirmationModal';
-import { ChapterDetails } from '@/pages/api/chapters/[chapterId]';
-
-const editChapter = async (id: number, updatedChapter: Chapter) => {
-  validateChapterInput(updatedChapter);
-
-  const response = await fetch(`/api/chapters/${id}`, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ updatedChapter }),
-  });
-
-  const responseJson = await response.json();
-  if (response.status !== 200) {
-    throw Error(responseJson.message);
-  }
-
-  if (responseJson.error) {
-    throw Error(responseJson.message);
-  }
-
-  return responseJson.chapter as ChapterDetails;
-};
+import EditChapterForm from './EditChapterForm';
 
 const EditChapterModal = () => {
-  const { activeChapter, setModalState } = useContext(ChapterModalContext);
-  const { chapters, upsertChapter } = useContext(ChaptersContext);
+  const { activeChapter } = useContext(ChapterModalContext);
+  const { chapters } = useContext(ChaptersContext);
 
   const chapterToEdit = chapters[activeChapter];
-  const [editedChapter, setEditedChapter] = useState<Chapter>(chapterToEdit);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    setEditedChapter(chapterToEdit);
-  }, [chapterToEdit]);
-
-  const {
-    handleSubmit,
-    register,
-    formState: { errors, isSubmitting, isDirty },
-  } = useForm<Chapter>({
-    defaultValues: {
-      ...chapterToEdit,
-    },
-  });
-
-  // Manage edit confirmation modal
-  const { isOpen, onOpen, onClose } = useDisclosure();
-
-  const onCancel = () => {
-    setModalState(ModalState.ViewChapter);
-  };
-
-  const onSubmit = async (data: Chapter) => {
-    // If valid inputs, open confirmation modal
-    setEditedChapter(data);
-    onOpen();
-  };
-
-  const onConfirmation = async () => {
-    setLoading(true);
-    editChapter(activeChapter, editedChapter)
-      .then((newChapter) => {
-        upsertChapter(newChapter);
-        setModalState(ModalState.ViewChapter);
-      })
-      .catch((err) => {
-        alert(err);
-      })
-      .finally(() => setLoading(false));
-  };
 
   return (
     <ModalContent>
       <ModalHeader>Edit Chapter {chapterToEdit?.chapterName}</ModalHeader>
       <ModalCloseButton />
       <ModalBody pb="5" mt="5" textAlign="center">
-        <EditConfirmationModal
-          isOpen={isOpen}
-          onClose={onClose}
-          onConfirmation={onConfirmation}
-          chapter={chapterToEdit}
-        />
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <FormControl
-            isRequired
-            isInvalid={errors.chapterName !== undefined}
-            mt={2}
-            mb={2}
-            id="chapterName"
-          >
-            <FormLabel htmlFor="chapterName">Chapter Name</FormLabel>
-            <Input
-              placeholder="Enter Name"
-              {...register('chapterName', {
-                required: 'Chapter Name is required',
-              })}
-              borderColor="black"
-            />
-            <FormErrorMessage>
-              {errors.chapterName && errors.chapterName.message}
-            </FormErrorMessage>
-          </FormControl>
-
-          <FormControl isRequired>
-            <FormLabel>Contact Info</FormLabel>
-          </FormControl>
-          <FormControl
-            isRequired
-            isInvalid={errors.contactName !== undefined}
-            mt={2}
-            mb={2}
-            id="contactName"
-          >
-            <Input
-              placeholder="Contact Name"
-              {...register('contactName', {
-                required: 'Contact name is required',
-              })}
-              borderColor="black"
-            />
-            <FormErrorMessage>
-              {errors.contactName && errors.contactName.message}
-            </FormErrorMessage>
-          </FormControl>
-
-          <SimpleGrid columns={[1, null, 2]} spacing={[0, null, 5]}>
-            <FormControl
-              isRequired
-              isInvalid={errors.email !== undefined}
-              mb={2}
-              id="email"
-            >
-              <Input
-                placeholder="Email"
-                type="email"
-                {...register('email', {
-                  required: 'Email is required',
-                  pattern: {
-                    value: emailRegex,
-                    message: 'Invalid email address',
-                  },
-                })}
-                borderColor="black"
-              />
-              <FormErrorMessage>
-                {errors.email && errors.email.message}
-              </FormErrorMessage>
-            </FormControl>
-
-            <FormControl
-              isInvalid={errors.phoneNumber !== undefined}
-              mb={2}
-              id="phoneNumber"
-            >
-              <Input
-                placeholder="Phone Number (Optional)"
-                type="number"
-                {...register('phoneNumber')}
-                borderColor="black"
-              />
-              <FormErrorMessage>
-                {errors.phoneNumber && errors.phoneNumber.message}
-              </FormErrorMessage>
-            </FormControl>
-          </SimpleGrid>
-
-          <Divider my="5" />
-
-          <Flex>
-            <Button
-              colorScheme="blue"
-              isLoading={isSubmitting || loading}
-              disabled={!isDirty}
-              type="submit"
-            >
-              Save
-            </Button>
-
-            <Spacer />
-            <Button
-              disabled={isSubmitting || loading}
-              onClick={onCancel}
-              variant="ghost"
-            >
-              Cancel
-            </Button>
-          </Flex>
-        </form>
+        <EditChapterForm chapterToEdit={chapterToEdit} />
       </ModalBody>
     </ModalContent>
   );

--- a/src/components/chapter-modals/EditChapterModal.tsx
+++ b/src/components/chapter-modals/EditChapterModal.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import {
+  Divider,
   ModalBody,
   ModalCloseButton,
   ModalContent,
@@ -8,6 +9,7 @@ import {
 import { ChapterModalContext } from '@/providers/ChapterModalProvider';
 import { ChaptersContext } from '@/providers/ChaptersProvider';
 import EditChapterForm from './EditChapterForm';
+import EditCredentialsForm from './EditCredentialsForm';
 
 const EditChapterModal = () => {
   const { activeChapter } = useContext(ChapterModalContext);
@@ -20,6 +22,8 @@ const EditChapterModal = () => {
       <ModalHeader>Edit Chapter {chapterToEdit?.chapterName}</ModalHeader>
       <ModalCloseButton />
       <ModalBody pb="5" mt="5" textAlign="center">
+        <EditCredentialsForm chapterToEdit={chapterToEdit} />
+        <Divider my="5" />
         <EditChapterForm chapterToEdit={chapterToEdit} />
       </ModalBody>
     </ModalContent>

--- a/src/components/chapter-modals/EditConfirmationModal.tsx
+++ b/src/components/chapter-modals/EditConfirmationModal.tsx
@@ -15,6 +15,7 @@ import { Chapter } from '@prisma/client';
 
 interface EditConfirmationProps {
   isOpen: boolean;
+  message: string;
   onClose: () => void;
   onConfirmation: () => void;
   chapter: Chapter;
@@ -25,6 +26,7 @@ const EditConfirmationModal = ({
   onClose,
   chapter,
   onConfirmation,
+  message,
 }: EditConfirmationProps) => {
   const onCancel = () => onClose();
   const onConfirm = () => {
@@ -41,7 +43,7 @@ const EditConfirmationModal = ({
           <Text fontSize="4xl" my="5">
             Are you sure?
           </Text>
-          <Text color="gray.500">This action will update chapter</Text>
+          <Text color="gray.500">{message}</Text>
           <Text fontSize="3xl">{chapter?.chapterName}</Text>
           <Text color="gray.500">This action cannot be undone</Text>
           <Divider my="5" />

--- a/src/components/chapter-modals/EditCredentialsForm.tsx
+++ b/src/components/chapter-modals/EditCredentialsForm.tsx
@@ -1,0 +1,130 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { User } from '@prisma/client';
+import {
+  Button,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Spacer,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { ChapterDetails } from '@/pages/api/chapters/[chapterId]';
+import {
+  ChapterModalContext,
+  ModalState,
+} from '@/providers/ChapterModalProvider';
+import { ChaptersContext } from '@/providers/ChaptersProvider';
+
+interface EditCredentialsForm {
+  chapterToEdit: ChapterDetails;
+}
+
+const EditCredentialsForm = ({ chapterToEdit }: EditCredentialsForm) => {
+  const { activeChapter, setModalState } = useContext(ChapterModalContext);
+  const { upsertChapter } = useContext(ChaptersContext);
+
+  const userToEdit = chapterToEdit?.chapterUser?.user || null;
+
+  const [loading, setLoading] = useState(false);
+  const [editedUser, setEditedUser] = useState<User | null>(userToEdit);
+
+  const {
+    handleSubmit,
+    register,
+    formState: { errors, isSubmitting, isDirty },
+  } = useForm<User>({
+    defaultValues: {
+      ...editedUser,
+      hash: '',
+    },
+  });
+
+  // Manage edit confirmation modal
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const onCancel = () => {
+    setModalState(ModalState.ViewChapter);
+  };
+
+  const onSubmit = async (data: User) => {
+    // If valid inputs, open confirmfation modal
+    setEditedUser(data);
+    onOpen();
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <FormControl isRequired>
+          <FormLabel>Credentials</FormLabel>
+        </FormControl>
+
+        <FormControl
+          isRequired
+          isInvalid={errors.username !== undefined}
+          my={2}
+          id="username"
+        >
+          <Input
+            placeholder="Username"
+            {...register('username', {
+              required: 'Username is required',
+            })}
+            borderColor="black"
+          />
+          <FormErrorMessage>
+            {errors.username && errors.username.message}
+          </FormErrorMessage>
+        </FormControl>
+
+        <FormControl
+          isRequired
+          isInvalid={errors.hash !== undefined}
+          my={2}
+          id="hash"
+        >
+          <Input
+            placeholder="Password"
+            {...register('hash', {
+              required: 'Password is required',
+              minLength: {
+                value: 8,
+                message: 'Minimum length should be 8',
+              },
+            })}
+            borderColor="black"
+          />
+          <FormErrorMessage>
+            {errors.hash && errors.hash.message}
+          </FormErrorMessage>
+        </FormControl>
+
+        <Flex my="3">
+          <Button
+            colorScheme="blue"
+            isLoading={isSubmitting || loading}
+            disabled={!isDirty}
+            type="submit"
+          >
+            Save
+          </Button>
+
+          <Spacer />
+
+          <Button
+            disabled={isSubmitting || loading}
+            onClick={onCancel}
+            variant="ghost"
+          >
+            Cancel
+          </Button>
+        </Flex>
+      </form>
+    </>
+  );
+};
+
+export default EditCredentialsForm;

--- a/src/components/chapter-modals/EditCredentialsForm.tsx
+++ b/src/components/chapter-modals/EditCredentialsForm.tsx
@@ -17,6 +17,7 @@ import {
   ModalState,
 } from '@/providers/ChapterModalProvider';
 import { ChaptersContext } from '@/providers/ChaptersProvider';
+import EditConfirmationModal from './EditConfirmationModal';
 
 interface EditCredentialsForm {
   chapterToEdit: ChapterDetails;
@@ -55,8 +56,21 @@ const EditCredentialsForm = ({ chapterToEdit }: EditCredentialsForm) => {
     onOpen();
   };
 
+  const onConfirmation = async () => {
+    alert(
+      `Updating the user credentials:\n${JSON.stringify(editedUser, null, 4)}`,
+    );
+  };
+
   return (
     <>
+      <EditConfirmationModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onConfirmation={onConfirmation}
+        chapter={chapterToEdit}
+        message="This action will update user credentials for chapter"
+      />
       <form onSubmit={handleSubmit(onSubmit)}>
         <FormControl isRequired>
           <FormLabel>Credentials</FormLabel>


### PR DESCRIPTION
### Description
This PR allows admins to update user credentials for chapter users. The form is added in the Chapter edit modal.

**Related Issues/PRs:** 
- Closes #104

### Test Plan

- Follow steps from #87 to open modal to update chapter information.
![image](https://user-images.githubusercontent.com/43834826/140810136-b6c51df7-f7f4-490a-bf19-408ce9d50b89.png)

- Enter new credentials and click save. This should show a confirmation modal.
![image](https://user-images.githubusercontent.com/43834826/140810360-2a728c61-a06d-4395-8c29-bd1c7a258f36.png)

- Verify the username is updated on the view chapter modal. In addition, check the database to see the username and password have been updated.

