### PR TITLE
Varsh emily/140/delete supply request

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/src/components/RecipientDetails.tsx
+++ b/src/components/RecipientDetails.tsx
@@ -4,6 +4,8 @@ import { IoIosSchool } from 'react-icons/io';
 import { RecipientsContext } from '@/providers/RecipientsProvider';
 import { DetailedRecipient } from '@/pages/api/chapters/[chapterId]/recipients';
 import SupplyRequestList from './SupplyRequestList';
+import SupplyRequestModalController from '@/components/supply-request-modals/SupplyRequestModalController';
+import { SupplyRequestModalProvider } from '@/providers/SupplyRequestModalProvider';
 
 interface RecipientDetailsProps {
   recipientId: number;
@@ -54,8 +56,13 @@ function RecipientDetails({ recipientId }: RecipientDetailsProps) {
       px={10}
       py={6}
     >
-      <Heading mb={8}>Supply Requests</Heading>
-      <SupplyRequestList data={activeRecipient.supplyRequests} />
+      <SupplyRequestModalProvider>
+        <>
+          <SupplyRequestModalController />
+          <Heading mb={8}>Supply Requests</Heading>
+          <SupplyRequestList data={activeRecipient.supplyRequests} />
+        </>
+      </SupplyRequestModalProvider>
     </Box>
   );
 }

--- a/src/components/SupplyRequestList.tsx
+++ b/src/components/SupplyRequestList.tsx
@@ -40,7 +40,7 @@ interface SupplyRequestListProps {
   data: DetailedSupplyRequest[];
 }
 
-function RowContextMenu(request: number, recipientId: number) {
+function RowContextMenu(requestId: number, recipientId: number) {
   const {
     onOpen,
     setModalState,
@@ -50,7 +50,7 @@ function RowContextMenu(request: number, recipientId: number) {
 
   const onDeleteSupplyRequest = () => {
     setActiveRecipientId(recipientId);
-    setActiveSupplyRequestId(request);
+    setActiveSupplyRequestId(requestId);
     setModalState(ModalState.DeleteSupplyRequest);
     onOpen();
   };

--- a/src/components/SupplyRequestList.tsx
+++ b/src/components/SupplyRequestList.tsx
@@ -1,5 +1,12 @@
 /* eslint-disable react/jsx-key */
-import { ReactChild, ReactFragment, ReactPortal, useMemo } from 'react';
+import {
+  ReactChild,
+  ReactFragment,
+  ReactPortal,
+  useMemo,
+  useContext,
+} from 'react';
+
 import {
   Flex,
   IconButton,
@@ -24,12 +31,29 @@ import {
   BsCaretDownFill,
 } from 'react-icons/bs';
 import { DetailedSupplyRequest } from '@/pages/api/recipients/[recId]/supply-requests';
+import {
+  SupplyRequestModalContext,
+  ModalState,
+} from '@/providers/SupplyRequestModalProvider';
 
 interface SupplyRequestListProps {
   data: DetailedSupplyRequest[];
 }
 
-function RowContextMenu() {
+function RowContextMenu(request: number, recipientId: number) {
+  const {
+    onOpen,
+    setModalState,
+    setActiveSupplyRequestId,
+    setActiveRecipientId,
+  } = useContext(SupplyRequestModalContext);
+
+  const onDeleteSupplyRequest = () => {
+    setActiveRecipientId(recipientId);
+    setActiveSupplyRequestId(request);
+    setModalState(ModalState.DeleteSupplyRequest);
+    onOpen();
+  };
   return (
     <Popover placement="bottom-end">
       <PopoverTrigger>
@@ -65,7 +89,7 @@ function RowContextMenu() {
               color="red"
               alignItems="center"
               justifyContent="flex-start"
-              onClick={() => console.log('Delete supply request.')}
+              onClick={onDeleteSupplyRequest}
             >
               <BsTrashFill />
               <Text ml="3">Delete Supply Request</Text>
@@ -387,7 +411,7 @@ export default function SupplyRequestList({ data }: SupplyRequestListProps) {
                 marginRight={1}
                 cursor="pointer"
               >
-                <RowContextMenu />
+                {RowContextMenu(row.original.id, row.original.recipientId)}
               </Box>
             </Box>
           );

--- a/src/components/supply-request-modals/DeleteSupplyRequestModal.tsx
+++ b/src/components/supply-request-modals/DeleteSupplyRequestModal.tsx
@@ -16,10 +16,6 @@ import {
 import { RecipientsContext } from '@/providers/RecipientsProvider';
 
 const deleteSupplyRequest = async (supplyId: number, recId: number) => {
-  // TODO: Change this to call the delete supply request api
-  // const response = await fetch(`/api/chapters/${id}`, {
-  console.log(supplyId);
-  console.log(recId);
   const response = await fetch(
     `/api/recipients/${recId}/supply-requests/${supplyId}`,
     {
@@ -46,8 +42,7 @@ const DeleteSupplyRequestModal = () => {
     setModalState,
     setActiveSupplyRequestId,
   } = useContext(SupplyRequestModalContext);
-  // const recipients = await getRecipients()
-  const { recipients, upsertRecipient } = useContext(RecipientsContext); // TODO: need to use these functions to update recipient data
+  const { recipients, upsertRecipient } = useContext(RecipientsContext);
   const [loading, setLoading] = useState(false);
   const onConfirmation = () => {
     setLoading(true);
@@ -55,7 +50,6 @@ const DeleteSupplyRequestModal = () => {
       .then(() => {
         onClose();
         setModalState(ModalState.NewSupplyRequest);
-        // TODO: Call upsertRecipient here to update recipient supply request based on recipients and activeRecipientId
         upsertRecipient(recipients[activeRecipientId]);
         setActiveSupplyRequestId(-1);
       })
@@ -67,11 +61,6 @@ const DeleteSupplyRequestModal = () => {
         setLoading(false);
       });
   };
-  // const chapterToDelete = chapters[activeSupplyRequest];
-  // TODO: instead of chapterToDelete, find the supply request to delete
-  // const supplyRequestToDelete =
-  //   recipients[activeRecipientId].supplyRequests[activeSupplyRequestId];
-  // console.log(recipients);
 
   const onCancel = () => {
     onClose();
@@ -84,9 +73,9 @@ const DeleteSupplyRequestModal = () => {
         <Text fontSize="4xl" my="5">
           Are you sure?
         </Text>
-        <Text color="gray.500">This action will delete supply request </Text>
-        {/* <Text fontSize="3xl">{chapterToDelete?.chapterName}</Text>  TODO: Need to figure out how to get the name of the supply request */}
-        {/* <Text fontSize="3xl">{supplyRequestToDelete?.item}</Text> */}
+        <Text color="gray.500">
+          This action will delete this supply request
+        </Text>
         <Text color="gray.500">This action cannot be undone</Text>
         <Divider my="5" />
         <Flex>

--- a/src/components/supply-request-modals/DeleteSupplyRequestModal.tsx
+++ b/src/components/supply-request-modals/DeleteSupplyRequestModal.tsx
@@ -15,24 +15,29 @@ import {
 } from '@/providers/SupplyRequestModalProvider';
 import { RecipientsContext } from '@/providers/RecipientsProvider';
 
-const deleteSupplyRequest = async (id: number) => {
+const deleteSupplyRequest = async (supplyId: number, recId: number) => {
   // TODO: Change this to call the delete supply request api
   // const response = await fetch(`/api/chapters/${id}`, {
-  //   method: 'DELETE',
-  //   headers: {
-  //     'Content-Type': 'application/json',
-  //   },
-  // });
-  // const responseJson = await response.json();
-  // if (response.status !== 200) {
-  //   throw Error(responseJson.message);
-  // }
-  // if (responseJson.error) {
-  //   throw Error(responseJson.message);
-  // }
-  // return responseJson;
+  console.log(supplyId);
+  console.log(recId);
+  const response = await fetch(
+    `/api/recipients/${recId}/supply-requests/${supplyId}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+  const responseJson = await response.json();
+  if (response.status !== 200) {
+    throw Error(responseJson.message);
+  }
+  if (responseJson.error) {
+    throw Error(responseJson.message);
+  }
+  return responseJson;
 };
-
 const DeleteSupplyRequestModal = () => {
   const {
     onClose,
@@ -43,14 +48,14 @@ const DeleteSupplyRequestModal = () => {
   } = useContext(SupplyRequestModalContext);
   const { recipients, upsertRecipient } = useContext(RecipientsContext); // TODO: need to use these functions to update recipient data
   const [loading, setLoading] = useState(false);
-
   const onConfirmation = () => {
     setLoading(true);
-    deleteSupplyRequest(activeSupplyRequestId)
+    deleteSupplyRequest(activeSupplyRequestId, activeRecipientId)
       .then(() => {
         onClose();
         setModalState(ModalState.NewSupplyRequest);
         // TODO: Call upsertRecipient here to update recipient supply request based on recipients and activeRecipientId
+        upsertRecipient(recipients[activeRecipientId]);
         setActiveSupplyRequestId(-1);
       })
       .catch((err) => {
@@ -61,16 +66,14 @@ const DeleteSupplyRequestModal = () => {
         setLoading(false);
       });
   };
-
   // const chapterToDelete = chapters[activeSupplyRequest];
-
   // TODO: instead of chapterToDelete, find the supply request to delete
   // const supplyRequestToDelete =
+  //   recipients[activeRecipientId].supplyRequests[activeSupplyRequestId];
 
   const onCancel = () => {
     onClose();
   };
-
   return (
     <ModalContent>
       <ModalCloseButton />
@@ -81,6 +84,7 @@ const DeleteSupplyRequestModal = () => {
         </Text>
         <Text color="gray.500">This action will delete supply request </Text>
         {/* <Text fontSize="3xl">{chapterToDelete?.chapterName}</Text>  TODO: Need to figure out how to get the name of the supply request */}
+        {/* <Text fontSize="3xl">{supplyRequestToDelete?.item}</Text> */}
         <Text color="gray.500">This action cannot be undone</Text>
         <Divider my="5" />
         <Flex>
@@ -100,5 +104,4 @@ const DeleteSupplyRequestModal = () => {
     </ModalContent>
   );
 };
-
 export default DeleteSupplyRequestModal;

--- a/src/components/supply-request-modals/DeleteSupplyRequestModal.tsx
+++ b/src/components/supply-request-modals/DeleteSupplyRequestModal.tsx
@@ -1,0 +1,104 @@
+import React, { useContext, useState } from 'react';
+import {
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  Button,
+  Text,
+  Flex,
+  Spacer,
+  Divider,
+} from '@chakra-ui/react';
+import {
+  SupplyRequestModalContext,
+  ModalState,
+} from '@/providers/SupplyRequestModalProvider';
+import { RecipientsContext } from '@/providers/RecipientsProvider';
+
+const deleteSupplyRequest = async (id: number) => {
+  // TODO: Change this to call the delete supply request api
+  // const response = await fetch(`/api/chapters/${id}`, {
+  //   method: 'DELETE',
+  //   headers: {
+  //     'Content-Type': 'application/json',
+  //   },
+  // });
+  // const responseJson = await response.json();
+  // if (response.status !== 200) {
+  //   throw Error(responseJson.message);
+  // }
+  // if (responseJson.error) {
+  //   throw Error(responseJson.message);
+  // }
+  // return responseJson;
+};
+
+const DeleteSupplyRequestModal = () => {
+  const {
+    onClose,
+    activeSupplyRequestId,
+    activeRecipientId,
+    setModalState,
+    setActiveSupplyRequestId,
+  } = useContext(SupplyRequestModalContext);
+  const { recipients, upsertRecipient } = useContext(RecipientsContext);
+  const [loading, setLoading] = useState(false);
+
+  const onConfirmation = () => {
+    setLoading(true);
+    deleteSupplyRequest(activeSupplyRequestId)
+      .then(() => {
+        onClose();
+        setModalState(ModalState.NewSupplyRequest);
+        // TODO: Call upsertRecipient here to update recipient supply request based on recipients and activeRecipientId
+        setActiveSupplyRequestId(-1);
+      })
+      .catch((err) => {
+        alert(err);
+        onClose();
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  // const chapterToDelete = chapters[activeSupplyRequest];
+
+  // TODO: instead of chapterToDelete, find the supply request to delete
+  // const supplyRequestToDelete =
+
+  const onCancel = () => {
+    onClose();
+  };
+
+  return (
+    <ModalContent>
+      <ModalCloseButton />
+      <ModalBody pb="5" mt="5" textAlign="center">
+        {/* Add icon to bring attention to user */}
+        <Text fontSize="4xl" my="5">
+          Are you sure?
+        </Text>
+        <Text color="gray.500">This action will delete supply request </Text>
+        {/* <Text fontSize="3xl">{chapterToDelete?.chapterName}</Text>  TODO: Need to figure out how to get the name of the supply request */}
+        <Text color="gray.500">This action cannot be undone</Text>
+        <Divider my="5" />
+        <Flex>
+          <Button
+            colorScheme="red"
+            isLoading={loading}
+            onClick={onConfirmation}
+          >
+            Delete
+          </Button>
+          <Spacer />
+          <Button disabled={loading} onClick={onCancel}>
+            Cancel
+          </Button>
+        </Flex>
+      </ModalBody>
+    </ModalContent>
+  );
+};
+
+export default DeleteSupplyRequestModal;

--- a/src/components/supply-request-modals/DeleteSupplyRequestModal.tsx
+++ b/src/components/supply-request-modals/DeleteSupplyRequestModal.tsx
@@ -41,7 +41,7 @@ const DeleteSupplyRequestModal = () => {
     setModalState,
     setActiveSupplyRequestId,
   } = useContext(SupplyRequestModalContext);
-  const { recipients, upsertRecipient } = useContext(RecipientsContext);
+  const { recipients, upsertRecipient } = useContext(RecipientsContext); // TODO: need to use these functions to update recipient data
   const [loading, setLoading] = useState(false);
 
   const onConfirmation = () => {

--- a/src/components/supply-request-modals/DeleteSupplyRequestModal.tsx
+++ b/src/components/supply-request-modals/DeleteSupplyRequestModal.tsx
@@ -46,6 +46,7 @@ const DeleteSupplyRequestModal = () => {
     setModalState,
     setActiveSupplyRequestId,
   } = useContext(SupplyRequestModalContext);
+  // const recipients = await getRecipients()
   const { recipients, upsertRecipient } = useContext(RecipientsContext); // TODO: need to use these functions to update recipient data
   const [loading, setLoading] = useState(false);
   const onConfirmation = () => {
@@ -70,6 +71,7 @@ const DeleteSupplyRequestModal = () => {
   // TODO: instead of chapterToDelete, find the supply request to delete
   // const supplyRequestToDelete =
   //   recipients[activeRecipientId].supplyRequests[activeSupplyRequestId];
+  // console.log(recipients);
 
   const onCancel = () => {
     onClose();

--- a/src/components/supply-request-modals/SupplyRequestModalController.tsx
+++ b/src/components/supply-request-modals/SupplyRequestModalController.tsx
@@ -13,7 +13,6 @@ import {
   ModalState,
 } from '@/providers/SupplyRequestModalProvider';
 import DeleteSupplyRequestModal from './DeleteSupplyRequestModal';
-// import EditSupplyRequestModal from './EditSupplyRequestModal';
 
 interface SupplyRequestModalContentProps {
   state: ModalState;

--- a/src/components/supply-request-modals/SupplyRequestModalController.tsx
+++ b/src/components/supply-request-modals/SupplyRequestModalController.tsx
@@ -22,8 +22,7 @@ const SupplyRequestModalContent = ({
   state,
 }: SupplyRequestModalContentProps) => {
   switch (state) {
-    // case ModalState.EditSupplyRequest:
-    //   return <EditSupplyRequestModal />;
+    // Add edit case here
     case ModalState.DeleteSupplyRequest:
       return <DeleteSupplyRequestModal />;
     default:

--- a/src/components/supply-request-modals/SupplyRequestModalController.tsx
+++ b/src/components/supply-request-modals/SupplyRequestModalController.tsx
@@ -1,0 +1,56 @@
+import React, { useContext } from 'react';
+import {
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react';
+import { Recipient } from '@prisma/client';
+import {
+  SupplyRequestModalContext,
+  ModalState,
+} from '@/providers/SupplyRequestModalProvider';
+import DeleteSupplyRequestModal from './DeleteSupplyRequestModal';
+// import EditSupplyRequestModal from './EditSupplyRequestModal';
+
+interface SupplyRequestModalContentProps {
+  state: ModalState;
+}
+
+const SupplyRequestModalContent = ({
+  state,
+}: SupplyRequestModalContentProps) => {
+  switch (state) {
+    // case ModalState.EditSupplyRequest:
+    //   return <EditSupplyRequestModal />;
+    case ModalState.DeleteSupplyRequest:
+      return <DeleteSupplyRequestModal />;
+    default:
+      return (
+        <ModalContent>
+          <ModalHeader>SupplyRequest</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb="5">
+            <h1>No Modal created for this action</h1>
+          </ModalBody>
+        </ModalContent>
+      );
+  }
+};
+
+const SupplyRequestModalController = () => {
+  const { isOpen, onClose, currentModalState } = useContext(
+    SupplyRequestModalContext,
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered size="xl">
+      <ModalOverlay />
+      <SupplyRequestModalContent state={currentModalState} />
+    </Modal>
+  );
+};
+
+export default SupplyRequestModalController;

--- a/src/pages/recipient/index.tsx
+++ b/src/pages/recipient/index.tsx
@@ -20,6 +20,8 @@ import { NextIronServerSideContext } from '@/utils/session';
 import { withRecipientAuthPage } from '@/utils/middlewares/auth';
 import { SessionRecipientUser } from '../api/recipients/login';
 import SupplyRequestList from '@/components/SupplyRequestList';
+import SupplyRequestModalController from '@/components/supply-request-modals/SupplyRequestModalController';
+import { SupplyRequestModalProvider } from '@/providers/SupplyRequestModalProvider';
 import { GetSupplyRequestsResponse } from '../api/recipients/[recId]/supply-requests';
 import RecipientNavbar from '@/components/navbars/RecipientNavbar';
 import { NAVBAR_HEIGHT } from '@/styles/theme';
@@ -69,31 +71,36 @@ export default function RecipientMapPage({
             state={recipient?.state || ''}
             postalCode={recipient?.postalCode || ''}
           />
-          <Stack
-            bgColor="white"
-            py={8}
-            px={10}
-            minH="500px"
-            boxShadow="lg"
-            borderRadius="lg"
-            borderWidth="1px"
-            spacing={8}
-          >
-            <Flex align="center" justifyContent="space-between">
-              <Heading>Supply Requests</Heading>
-              <Button leftIcon={<BsPlus />} onClick={onOpen}>
-                Add New
-              </Button>
-            </Flex>
-            {recipientError && <Text>{recipientError}</Text>}
-            {isLoading ? (
-              <Center>
-                <Spinner />
-              </Center>
-            ) : (
-              <SupplyRequestList data={data.items} />
-            )}
-          </Stack>
+          <SupplyRequestModalProvider>
+            <Stack
+              bgColor="white"
+              py={8}
+              px={10}
+              minH="500px"
+              boxShadow="lg"
+              borderRadius="lg"
+              borderWidth="1px"
+              spacing={8}
+            >
+              <Flex align="center" justifyContent="space-between">
+                <Heading>Supply Requests</Heading>
+                <Button leftIcon={<BsPlus />} onClick={onOpen}>
+                  Add New
+                </Button>
+              </Flex>
+              {recipientError && <Text>{recipientError}</Text>}
+              {isLoading ? (
+                <Center>
+                  <Spinner />
+                </Center>
+              ) : (
+                <>
+                  <SupplyRequestModalController />
+                  <SupplyRequestList data={data.items} />
+                </>
+              )}
+            </Stack>
+          </SupplyRequestModalProvider>
         </Grid>
       </Box>
       {recipient && (

--- a/src/providers/RecipientsProvider.tsx
+++ b/src/providers/RecipientsProvider.tsx
@@ -28,6 +28,7 @@ export const RecipientsContext = createContext<RecipientsContextProps>({
 });
 
 const getRecipients = async (chapterId: number) => {
+  // potentially add export
   if (!chapterId || chapterId < 0) {
     throw Error('Please provide a valid chapter id');
   }

--- a/src/providers/SupplyRequestModalProvider.tsx
+++ b/src/providers/SupplyRequestModalProvider.tsx
@@ -1,0 +1,77 @@
+import { useDisclosure } from '@chakra-ui/react';
+import { createContext, useState } from 'react';
+
+// eslint-disable-next-line no-shadow
+export enum ModalState {
+  NewSupplyRequest,
+  EditSupplyRequest,
+  DeleteSupplyRequest,
+}
+
+export interface SupplyRequestModalContextProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onOpen: () => void;
+  currentModalState: ModalState;
+  setModalState: (x: ModalState) => void;
+  activeRecipientId: number;
+  setActiveRecipientId: (id: number) => void;
+  activeSupplyRequestId: number;
+  setActiveSupplyRequestId: (id: number) => void;
+}
+
+export interface SupplyRequestModalProviderProps {
+  children: JSX.Element;
+}
+
+export const SupplyRequestModalContext =
+  createContext<SupplyRequestModalContextProps>({
+    isOpen: false,
+    activeSupplyRequestId: -1,
+    activeRecipientId: -1,
+    currentModalState: ModalState.NewSupplyRequest,
+    onClose: () => {
+      throw new Error('Method not implemented');
+    },
+    onOpen: () => {
+      throw new Error('Method not implemented');
+    },
+    setModalState: (x: ModalState) => {
+      throw new Error('Method not implemented');
+    },
+    setActiveSupplyRequestId: (x: number) => {
+      throw new Error('Method not implemented');
+    },
+    setActiveRecipientId: (x: number) => {
+      throw new Error('Method not implemented');
+    },
+  });
+
+export const SupplyRequestModalProvider = ({
+  children,
+}: SupplyRequestModalProviderProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [activeSupplyRequestId, setActiveSupplyRequestId] = useState<number>(0);
+  const [activeRecipientId, setActiveRecipientId] = useState<number>(0);
+  const [currentModalState, setModalState] = useState<ModalState>(
+    ModalState.NewSupplyRequest,
+  );
+
+  return (
+    <SupplyRequestModalContext.Provider
+      value={{
+        isOpen,
+        onOpen,
+        onClose,
+        currentModalState,
+        setModalState,
+        activeRecipientId,
+        setActiveRecipientId,
+        activeSupplyRequestId,
+        setActiveSupplyRequestId,
+      }}
+    >
+      {children}
+    </SupplyRequestModalContext.Provider>
+  );
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2015",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -15,10 +19,21 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@/public/*": ["./public/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ],
+      "@/public/*": [
+        "./public/*"
+      ]
+    },
+    "incremental": true
   },
-  "exclude": ["node_modules"],
-  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx"]
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
 }


### PR DESCRIPTION
### Description

Implemented delete supply request functionality on both the chapter and recipient side.

**Related Issues/PRs:** 

List of related issues/PRs and the type of association. For example:
- Closes #140 

### Test Plan

List of steps to test your proposed changes. Add screenshots if appropriate. For example: 

Chapter:
- Login as chapter
- Click on the "..." of a supply request
- click delete
- The supply request should delete, and frontend should update after refreshing the page 

Recipient:
- Login as a recipient
- Click on the "..." of a supply request
- click delete
- Currently, this function is broken, and the supply request does not delete for the recipient side
